### PR TITLE
work around erroneous soteria vulnerability error

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -878,7 +878,13 @@ pub fn append_instruction(instruction: &Instruction, dst: &mut Vec<u8>) {
     dst.put_u16_le(instruction.accounts.len() as u16);
     for account in instruction.accounts.iter() {
         let mut buf = vec![0; 1 + Signer::LEN];
-        buf[0] = if account.is_signer { 2 } else { 0 } + if account.is_writable { 1 } else { 0 };
+        buf[0] = 0;
+        if account.is_signer {
+            buf[0] |= 2;
+        }
+        if account.is_writable {
+            buf[0] |= 1;
+        }
         Signer::new(account.pubkey).pack_into_slice(&mut buf[1..1 + Signer::LEN]);
         dst.extend_from_slice(buf.as_slice());
     }


### PR DESCRIPTION
Tweak to avoid erroneous soteria vulnerability error

## Description
Use bit operations instead of addition, so soteria vulnerability scanner doesn't think there could be overflow

## Motivation and Context

## How Has This Been Tested?
Existing unit tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

