### PR TITLE
fixes several bugs related to verifying timeout transfers in test

### DIFF
--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -409,10 +409,8 @@ pub async fn setup_wallet_update_test() -> WalletUpdateContext {
         remove_address_book_entries: vec![(SlotId::new(0), address_book_entry)],
     };
 
-    let multisig_op = get_multisig_op_data(
-        &mut test_context.banks_client,
-        multisig_op_account.pubkey()
-    ).await;
+    let multisig_op =
+        get_multisig_op_data(&mut test_context.banks_client, multisig_op_account.pubkey()).await;
 
     assert!(multisig_op.is_initialized);
 
@@ -1058,7 +1056,6 @@ pub async fn setup_balance_account_tests(
         transfer_approvers.append(&mut vec![(SlotId::new(2), approvers[2].pubkey_as_signer())])
     }
 
-
     let init_transaction = Transaction::new_signed_with_payer(
         &[
             system_instruction::create_account(
@@ -1119,7 +1116,7 @@ pub async fn setup_balance_account_tests(
     let expected_update = BalanceAccountUpdate {
         name_hash: balance_account_name_hash,
         approvals_required_for_transfer: 2,
-        approval_timeout_for_transfer: approval_timeout_for_transfer,
+        approval_timeout_for_transfer,
         add_transfer_approvers: transfer_approvers.clone(),
         remove_transfer_approvers: vec![],
         add_allowed_destinations: vec![],
@@ -1345,11 +1342,13 @@ pub async fn setup_transfer_test(
         ))
         .await;
 
-    assert_multisig_op_timestamps(
-        &get_multisig_op_data(&mut context.banks_client, multisig_op_account.pubkey()).await,
-        initialized_at,
-        Duration::from_secs(120)
-    );
+    if result.is_ok() {
+        assert_multisig_op_timestamps(
+            &get_multisig_op_data(&mut context.banks_client, multisig_op_account.pubkey()).await,
+            initialized_at,
+            Duration::from_secs(120),
+        );
+    }
 
     (multisig_op_account, result)
 }
@@ -1382,7 +1381,7 @@ pub async fn modify_whitelist(
                 context.balance_account_guid_hash,
                 context.balance_account_name_hash,
                 2,
-                Duration::from_secs(7200),
+                Duration::from_secs(120),
                 vec![],
                 vec![],
                 destinations_to_add.clone(),
@@ -1432,7 +1431,7 @@ pub async fn modify_whitelist(
     let expected_config_update = BalanceAccountUpdate {
         name_hash: context.balance_account_name_hash,
         approvals_required_for_transfer: 2,
-        approval_timeout_for_transfer: Duration::from_secs(7200),
+        approval_timeout_for_transfer: Duration::from_secs(120),
         add_transfer_approvers: vec![],
         remove_transfer_approvers: vec![],
         add_allowed_destinations: destinations_to_add,


### PR DESCRIPTION
## Description
In `setup_transfer_test` we were checking the timestamps on the multisig op even if the init failed.
In `modify_whitelist` the transfer approval timeout was specified incorrectly.

## Motivation and Context
Failing unit tests

## How Has This Been Tested?
Unit tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

