### PR TITLE
Replace generic ProgramErrors with program-specific WalletErrors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,16 @@ build:
 analyze:
 	soteria -c -analyzeAll .
 
-deploy_and_test: build
+deploy:
 	solana program deploy ./target/deploy/strike_wallet.so
-	cargo test-bpf
 
 test:
+	# Note that test-bpf builds then tests. No need to do `make build`
+	# beforehand.  To target a specific module, do `make test -e
+	# tests=<SPECIFIC_MODULE_NAME>`.
 	cargo test-bpf ${tests} -- --nocapture
+
+deploy_and_test: build deploy test
+
+clean:
+	rm -r target

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,40 +3,90 @@ use thiserror::Error;
 
 #[derive(Error, Debug, Copy, Clone)]
 pub enum WalletError {
+    // 0
+    /// Unexpected account in instruction.
+    #[error("Account Not Recognized")]
+    AccountNotRecognized,
+    /// Source account for transfer not recognized.
     #[error("Invalid Source Account")]
     InvalidSourceAccount,
+    /// Approver account is not configured as a Signer or, more generally, a
+    /// required signature is invalid or missing.
     #[error("Invalid Signature")]
     InvalidSignature,
+    /// Account included in instruction is not a valid Approver.
     #[error("Invalid Approver")]
     InvalidApprover,
-    #[error("Invalid Disposition")]
+    /// The disposition of an Approval is invalid for the executing instruction.
+    #[error("Invalid Approval Disposition")]
     InvalidDisposition,
-    #[error("Transfer Disposition Not Final")]
-    TransferDispositionNotFinal,
-    #[error("Amount Overflow")]
-    AmountOverflow,
-    #[error("InSufficient Balance")]
-    InsufficientBalance,
-    #[error("Destination Not Allowed")]
-    DestinationNotAllowed,
-    #[error("Balance Account Not Found")]
-    BalanceAccountNotFound,
-    #[error("Invalid Source Token Account")]
-    InvalidSourceTokenAccount,
-    #[error("Invalid Destination Token Account")]
-    InvalidDestinationTokenAccount,
-    #[error("Invalid Token Mint Account")]
-    InvalidTokenMintAccount,
+
+    // 5
+    /// Attempting to set Approval timeout beyond allowed min and max.
     #[error("Invalid Approval Timeout")]
     InvalidApprovalTimeout,
+    /// Tried to set the number of approvals required to invalid number, like
+    /// zero or more than the total number of Signers available.
+    #[error("Invalid Approver Count")]
+    InvalidApproverCount,
+    /// Tried to access an element of a collection that is either out-of-bounds
+    /// or unauthorized. E.G.: AddressBook entries, Transfer Approvers.
+    #[error("Invalid Slot")]
+    InvalidSlot,
+    /// TransferDispositionNotFinal used internally in MultisigOp finalization.
+    #[error("Transfer Disposition Not Final")]
+    TransferDispositionNotFinal,
+    /// Attempting to transfer an invalid amount between accounts.
+    #[error("Amount Overflow")]
+    AmountOverflow,
+
+    // 10
+    /// Insufficient balance for a transfer.
+    #[error("InSufficient Balance")]
+    InsufficientBalance,
+    /// Destination address not allowed in a transfer.
+    #[error("Destination Not Allowed")]
+    DestinationNotAllowed,
+    /// Balance Account referenced by an instruction does not exist.
+    #[error("Balance Account Not Found")]
+    BalanceAccountNotFound,
+    /// Invalid SPL source token account.
+    #[error("Invalid Source Token Account")]
+    InvalidSourceTokenAccount,
+    /// Invalid SPL destination token account.
+    #[error("Invalid Destination Token Account")]
+    InvalidDestinationTokenAccount,
+
+    // 15
+    /// Invalid SPL token mint account.
+    #[error("Invalid Token Mint Account")]
+    InvalidTokenMintAccount,
+    /// Only one policy config change can be initiated at a time.
     #[error("Concurrent Operations Not Allowed")]
     ConcurrentOperationsNotAllowed,
+    /// Simulation of MultisigOp finalization completed normally.
     #[error("Simulation Finished Successfully")]
     SimulationFinished,
+    /// Cannot whitelist an address when Whitelisting is not enabled.
     #[error("Whitelist Is Disabled")]
     WhitelistDisabled,
+    /// Cannot disable Whitelisting while one or more address is whitelisted.
+    #[error("Whitelisting In Use")]
+    WhitelistedAddressInUse,
+
+    // 20
+    /// The set of Approvers for transfers or config changes must not be empty.
+    #[error("No Approvers Enabled")]
+    NoApproversEnabled,
+    /// DApp transactions are disabled.
     #[error("DApp Transactions Are Disabled")]
     DAppsDisabled,
+    /// Slot Already In Use
+    #[error("Slot Already In Use")]
+    SlotAlreadyInUse,
+    /// Unknown Signer
+    #[error("Unknown Signer")]
+    UnknownSigner,
 }
 
 impl From<WalletError> for ProgramError {

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -537,7 +537,7 @@ impl Processor {
         let is_spl = token_mint.to_bytes() != [0; 32];
 
         if system_program_account.key != &system_program::id() {
-            return Err(ProgramError::InvalidArgument);
+            return Err(WalletError::AccountNotRecognized.into());
         }
 
         finalize_multisig_op(
@@ -714,7 +714,7 @@ impl Processor {
         let wrapped_sol_account_info = next_account_info(accounts_iter)?;
 
         if system_program_account_info.key != &system_program::id() {
-            return Err(ProgramError::InvalidArgument);
+            return Err(WalletError::AccountNotRecognized.into());
         }
 
         finalize_multisig_op(

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -1200,6 +1200,21 @@ pub async fn setup_create_balance_account_failure_tests(
 
     let approvers = vec![Keypair::new(), Keypair::new(), Keypair::new()];
 
+    // add given transfer approvers to signers
+    let mut signers = transfer_approvers
+        .iter()
+        .enumerate()
+        .map(|(i, pk)| (SlotId::new(i), Signer::new(*pk)))
+        .collect_vec();
+
+    // add a couple random signers to ensure init wallet has a non-zero signers
+    // vec in case the given transfer_approvers vec has insufficient len.
+    for _ in 0..2 {
+        signers.push((SlotId::new(signers.len()), approvers[0].pubkey_as_signer()));
+    }
+    // take the first two signers as config approvers
+    let config_approvers = signers[..2].to_vec();
+
     // first initialize the wallet
     init_wallet(
         &mut banks_client,
@@ -1209,14 +1224,8 @@ pub async fn setup_create_balance_account_failure_tests(
         &wallet_account,
         &assistant_account,
         Some(1),
-        Some(vec![
-            (SlotId::new(0), approvers[0].pubkey_as_signer()),
-            (SlotId::new(1), approvers[1].pubkey_as_signer()),
-        ]),
-        Some(vec![
-            (SlotId::new(0), approvers[0].pubkey_as_signer()),
-            (SlotId::new(1), approvers[1].pubkey_as_signer()),
-        ]),
+        Some(signers),
+        Some(config_approvers),
         Some(Duration::from_secs(3600)),
         Some(vec![]),
     )

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -1210,8 +1210,7 @@ pub async fn setup_create_balance_account_failure_tests(
     // vec in case the given transfer_approvers vec has insufficient length.
     approvers
         .iter()
-        .enumerate()
-        .for_each(|(i, kp)| signers.push((SlotId::new(signers.len() + i), kp.pubkey_as_signer())));
+        .for_each(|kp| signers.push((SlotId::new(signers.len()), kp.pubkey_as_signer())));
 
     // take the first two signers as config approvers
     let config_approvers = signers[..2].to_vec();

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -1208,12 +1208,10 @@ pub async fn setup_create_balance_account_failure_tests(
         .collect_vec();
 
     // add a couple random signers to ensure init wallet has a non-zero signers
-    // vec in case the given transfer_approvers vec has insufficient len.
+    // vec in case the given transfer_approvers vec has insufficient length.
     for _ in 0..2 {
         signers.push((SlotId::new(signers.len()), approvers[0].pubkey_as_signer()));
     }
-    // take the first two signers as config approvers
-    let config_approvers = signers[..2].to_vec();
 
     // first initialize the wallet
     init_wallet(
@@ -1225,7 +1223,7 @@ pub async fn setup_create_balance_account_failure_tests(
         &assistant_account,
         Some(1),
         Some(signers),
-        Some(config_approvers),
+        Some(signers.clone()),
         Some(Duration::from_secs(3600)),
         Some(vec![]),
     )

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -1206,12 +1206,15 @@ pub async fn setup_create_balance_account_failure_tests(
         .enumerate()
         .map(|(i, pk)| (SlotId::new(i), Signer::new(*pk)))
         .collect_vec();
-
     // add a couple random signers to ensure init wallet has a non-zero signers
     // vec in case the given transfer_approvers vec has insufficient length.
-    for _ in 0..2 {
-        signers.push((SlotId::new(signers.len()), approvers[0].pubkey_as_signer()));
-    }
+    approvers
+        .iter()
+        .enumerate()
+        .for_each(|(i, kp)| signers.push((SlotId::new(signers.len() + i), kp.pubkey_as_signer())));
+
+    // take the first two signers as config approvers
+    let config_approvers = signers[..2].to_vec();
 
     // first initialize the wallet
     init_wallet(
@@ -1223,7 +1226,7 @@ pub async fn setup_create_balance_account_failure_tests(
         &assistant_account,
         Some(1),
         Some(signers),
-        Some(signers.clone()),
+        Some(config_approvers),
         Some(Duration::from_secs(3600)),
         Some(vec![]),
     )

--- a/tests/wallet_config_policy_update_tests.rs
+++ b/tests/wallet_config_policy_update_tests.rs
@@ -1,10 +1,11 @@
 #![cfg(feature = "test-bpf")]
+
 mod common;
+
 pub use common::instructions::*;
+pub use common::utils;
 pub use common::utils::*;
 
-pub use common::utils;
-use solana_program::instruction::InstructionError;
 use solana_program::instruction::InstructionError::Custom;
 use solana_program_test::tokio;
 use solana_sdk::signature::Keypair;
@@ -323,7 +324,7 @@ async fn invalid_wallet_config_policy_updates() {
         )
         .await,
         1,
-        InstructionError::InvalidArgument,
+        Custom(WalletError::InvalidApproverCount as u32),
     );
 
     // verify it's not allowed to add a config approver that is not configured as signer
@@ -341,10 +342,10 @@ async fn invalid_wallet_config_policy_updates() {
         )
         .await,
         1,
-        InstructionError::InvalidArgument,
+        Custom(WalletError::UnknownSigner as u32),
     );
 
-    // verify it's not allowed to add a config approver when provided slot value does not match the stored one
+    // verify it's not allowed to add a config approver who isn't a signer.
     assert_instruction_error(
         utils::init_wallet_config_policy_update(
             &mut context,
@@ -359,9 +360,8 @@ async fn invalid_wallet_config_policy_updates() {
         )
         .await,
         1,
-        InstructionError::InvalidArgument,
+        Custom(WalletError::UnknownSigner as u32),
     );
-
     // verify it's not allowed to remove a config approver when provided slot value does not match the stored one
     assert_instruction_error(
         utils::init_wallet_config_policy_update(
@@ -377,6 +377,6 @@ async fn invalid_wallet_config_policy_updates() {
         )
         .await,
         1,
-        InstructionError::InvalidArgument,
+        Custom(WalletError::InvalidSlot as u32),
     );
 }

--- a/tests/whitelist_status_update_tests.rs
+++ b/tests/whitelist_status_update_tests.rs
@@ -5,7 +5,7 @@ mod common;
 pub use common::instructions::*;
 pub use common::utils::*;
 
-use solana_program::instruction::InstructionError::{Custom, InvalidArgument};
+use solana_program::instruction::InstructionError::Custom;
 use solana_program_test::tokio;
 use solana_sdk::transaction::TransactionError;
 use std::borrow::BorrowMut;
@@ -50,7 +50,7 @@ async fn test_whitelist_status() {
         &mut context,
         Some(BooleanSetting::Off),
         None,
-        Some(InvalidArgument),
+        Some(Custom(WalletError::WhitelistedAddressInUse as u32)),
     )
     .await;
 


### PR DESCRIPTION
- Replaced ProgramErrors with program-specific WalletErrors to make the cause of errors clearer.
- Added docstrings to WalletErrors, based on the format found in Solana Program Library. For example: https://github.com/solana-labs/solana-program-library/blob/master/token/program/src/error.rs
- Small refactoring in Makefile to make it more DRY.

## How Has This Been Tested?
Tests updated to catch new error codes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)

