### PR TITLE
refactor whitelist status in account settings; add dapps_enabled

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,8 @@ pub enum WalletError {
     SimulationFinished,
     #[error("Whitelisting Status is Off")]
     WhitelistingStatusOff,
+    #[error("DApp Transactions Are Disabled")]
+    DAppsDisabled,
 }
 
 impl From<WalletError> for ProgramError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,8 +33,8 @@ pub enum WalletError {
     ConcurrentOperationsNotAllowed,
     #[error("Simulation Finished Successfully")]
     SimulationFinished,
-    #[error("Whitelisting Status is Off")]
-    WhitelistingStatusOff,
+    #[error("Whitelist Is Disabled")]
+    WhitelistDisabled,
     #[error("DApp Transactions Are Disabled")]
     DAppsDisabled,
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,4 +1,4 @@
+pub mod account_settings_update_handler;
 pub mod dapp_transaction_handler;
 pub mod utils;
 pub mod wallet_config_policy_update_handler;
-pub mod whitelist_status_update_handler;

--- a/src/handlers/account_settings_update_handler.rs
+++ b/src/handlers/account_settings_update_handler.rs
@@ -14,7 +14,7 @@ pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     account_guid_hash: &BalanceAccountGuidHash,
-    whitelist_status: Option<BooleanSetting>,
+    whitelist_enabled: Option<BooleanSetting>,
     dapps_enabled: Option<BooleanSetting>,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
@@ -25,8 +25,8 @@ pub fn init(
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
     wallet.validate_config_initiator(initiator_account_info)?;
-    if let Some(status) = whitelist_status {
-        wallet.validate_whitelist_status_update(account_guid_hash, status)?;
+    if let Some(status) = whitelist_enabled {
+        wallet.validate_whitelist_enabled_update(account_guid_hash, status)?;
     }
 
     start_multisig_config_op(
@@ -36,7 +36,7 @@ pub fn init(
         MultisigOpParams::AccountSettingsUpdate {
             wallet_address: *wallet_account_info.key,
             account_guid_hash: *account_guid_hash,
-            whitelist_status,
+            whitelist_enabled,
             dapps_enabled,
         },
     )
@@ -46,7 +46,7 @@ pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     account_guid_hash: &BalanceAccountGuidHash,
-    whitelist_status: Option<BooleanSetting>,
+    whitelist_enabled: Option<BooleanSetting>,
     dapps_enabled: Option<BooleanSetting>,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
@@ -62,13 +62,13 @@ pub fn finalize(
         MultisigOpParams::AccountSettingsUpdate {
             wallet_address: *wallet_account_info.key,
             account_guid_hash: *account_guid_hash,
-            whitelist_status,
+            whitelist_enabled,
             dapps_enabled,
         },
         || -> ProgramResult {
             let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow_mut())?;
-            if let Some(status) = whitelist_status {
-                wallet.update_whitelist_status(&account_guid_hash, status)?;
+            if let Some(status) = whitelist_enabled {
+                wallet.update_whitelist_enabled(&account_guid_hash, status)?;
             }
             if let Some(enabled) = dapps_enabled {
                 wallet.update_dapps_enabled(&account_guid_hash, enabled)?;

--- a/src/handlers/account_settings_update_handler.rs
+++ b/src/handlers/account_settings_update_handler.rs
@@ -3,7 +3,7 @@ use crate::handlers::utils::{
     start_multisig_config_op,
 };
 use crate::model::balance_account::BalanceAccountGuidHash;
-use crate::model::multisig_op::{MultisigOpParams, WhitelistStatus};
+use crate::model::multisig_op::{BooleanSetting, MultisigOpParams};
 use crate::model::wallet::Wallet;
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
@@ -14,7 +14,8 @@ pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     account_guid_hash: &BalanceAccountGuidHash,
-    status: WhitelistStatus,
+    whitelist_status: Option<BooleanSetting>,
+    dapps_enabled: Option<BooleanSetting>,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
     let multisig_op_account_info = next_program_account_info(accounts_iter, program_id)?;
@@ -24,16 +25,19 @@ pub fn init(
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
     wallet.validate_config_initiator(initiator_account_info)?;
-    wallet.validate_whitelist_status_update(account_guid_hash, status)?;
+    if let Some(status) = whitelist_status {
+        wallet.validate_whitelist_status_update(account_guid_hash, status)?;
+    }
 
     start_multisig_config_op(
         &multisig_op_account_info,
         &wallet,
         clock,
-        MultisigOpParams::WhitelistStatusUpdate {
+        MultisigOpParams::AccountSettingsUpdate {
             wallet_address: *wallet_account_info.key,
             account_guid_hash: *account_guid_hash,
-            status,
+            whitelist_status,
+            dapps_enabled,
         },
     )
 }
@@ -42,7 +46,8 @@ pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     account_guid_hash: &BalanceAccountGuidHash,
-    status: WhitelistStatus,
+    whitelist_status: Option<BooleanSetting>,
+    dapps_enabled: Option<BooleanSetting>,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
     let multisig_op_account_info = next_program_account_info(accounts_iter, program_id)?;
@@ -54,14 +59,20 @@ pub fn finalize(
         &multisig_op_account_info,
         &account_to_return_rent_to,
         clock,
-        MultisigOpParams::WhitelistStatusUpdate {
+        MultisigOpParams::AccountSettingsUpdate {
             wallet_address: *wallet_account_info.key,
             account_guid_hash: *account_guid_hash,
-            status,
+            whitelist_status,
+            dapps_enabled,
         },
         || -> ProgramResult {
             let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow_mut())?;
-            wallet.update_whitelist_status(&account_guid_hash, status)?;
+            if let Some(status) = whitelist_status {
+                wallet.update_whitelist_status(&account_guid_hash, status)?;
+            }
+            if let Some(enabled) = dapps_enabled {
+                wallet.update_dapps_enabled(&account_guid_hash, enabled)?;
+            }
             Wallet::pack(wallet, &mut wallet_account_info.data.borrow_mut())?;
             Ok(())
         },

--- a/src/handlers/dapp_transaction_handler.rs
+++ b/src/handlers/dapp_transaction_handler.rs
@@ -33,6 +33,10 @@ pub fn init(
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
     let balance_account = wallet.get_balance_account(account_guid_hash)?;
 
+    if balance_account.are_dapps_disabled() {
+        return Err(WalletError::DAppsDisabled.into());
+    }
+
     wallet.validate_transfer_initiator(balance_account, initiator_account_info)?;
 
     let mut multisig_op = MultisigOp::unpack_unchecked(&multisig_op_account_info.data.borrow())?;

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -202,7 +202,7 @@ pub enum ProgramInstruction {
     /// 3. `[]` The sysvar clock account
     InitAccountSettingsUpdate {
         account_guid_hash: BalanceAccountGuidHash,
-        whitelist_status: Option<BooleanSetting>,
+        whitelist_enabled: Option<BooleanSetting>,
         dapps_enabled: Option<BooleanSetting>,
     },
 
@@ -211,7 +211,7 @@ pub enum ProgramInstruction {
     /// 2. `[signer]` The rent collector account
     FinalizeAccountSettingsUpdate {
         account_guid_hash: BalanceAccountGuidHash,
-        whitelist_status: Option<BooleanSetting>,
+        whitelist_enabled: Option<BooleanSetting>,
         dapps_enabled: Option<BooleanSetting>,
     },
 }
@@ -383,22 +383,22 @@ impl ProgramInstruction {
             }
             &ProgramInstruction::InitAccountSettingsUpdate {
                 ref account_guid_hash,
-                ref whitelist_status,
+                ref whitelist_enabled,
                 ref dapps_enabled,
             } => {
                 buf.push(18);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
-                pack_option(whitelist_status.as_ref(), &mut buf);
+                pack_option(whitelist_enabled.as_ref(), &mut buf);
                 pack_option(dapps_enabled.as_ref(), &mut buf);
             }
             &ProgramInstruction::FinalizeAccountSettingsUpdate {
                 ref account_guid_hash,
-                ref whitelist_status,
+                ref whitelist_enabled,
                 ref dapps_enabled,
             } => {
                 buf.push(19);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
-                pack_option(whitelist_status.as_ref(), &mut buf);
+                pack_option(whitelist_enabled.as_ref(), &mut buf);
                 pack_option(dapps_enabled.as_ref(), &mut buf);
             }
         }
@@ -689,7 +689,7 @@ impl ProgramInstruction {
             account_guid_hash: unpack_account_guid_hash(
                 utils::read_slice(iter, 32).ok_or(ProgramError::InvalidInstructionData)?,
             )?,
-            whitelist_status: utils::unpack_option::<BooleanSetting>(iter)?,
+            whitelist_enabled: utils::unpack_option::<BooleanSetting>(iter)?,
             dapps_enabled: utils::unpack_option::<BooleanSetting>(iter)?,
         })
     }
@@ -702,7 +702,7 @@ impl ProgramInstruction {
             account_guid_hash: unpack_account_guid_hash(
                 utils::read_slice(iter, 32).ok_or(ProgramError::InvalidInstructionData)?,
             )?,
-            whitelist_status: utils::unpack_option::<BooleanSetting>(iter)?,
+            whitelist_enabled: utils::unpack_option::<BooleanSetting>(iter)?,
             dapps_enabled: utils::unpack_option::<BooleanSetting>(iter)?,
         })
     }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,10 +1,10 @@
-use bytes::BufMut;
 use std::convert::TryInto;
 use std::mem::size_of;
 use std::slice::Iter;
 use std::time::Duration;
 
 use bitvec::macros::internal::funty::Fundamental;
+use bytes::BufMut;
 use solana_program::hash::Hash;
 use solana_program::program_error::ProgramError;
 use solana_program::program_pack::Pack;
@@ -13,10 +13,11 @@ use solana_program::{instruction::AccountMeta, instruction::Instruction, pubkey:
 use crate::model::address_book::{AddressBookEntry, AddressBookEntryNameHash};
 use crate::model::balance_account::{BalanceAccountGuidHash, BalanceAccountNameHash};
 use crate::model::multisig_op::{
-    ApprovalDisposition, SlotUpdateType, WhitelistStatus, WrapDirection,
+    ApprovalDisposition, BooleanSetting, SlotUpdateType, WrapDirection,
 };
 use crate::model::signer::Signer;
-use crate::utils::SlotId;
+use crate::utils;
+use crate::utils::{pack_option, SlotId};
 
 #[derive(Debug)]
 pub enum ProgramInstruction {
@@ -194,21 +195,24 @@ pub enum ProgramInstruction {
         account_guid_hash: BalanceAccountGuidHash,
         instructions: Vec<Instruction>,
     },
+
     /// 0  `[writable]` The multisig operation account
     /// 1. `[]` The wallet account
     /// 2. `[signer]` The initiator account (either the transaction assistant or an approver)
     /// 3. `[]` The sysvar clock account
-    InitWhitelistStatusUpdate {
+    InitAccountSettingsUpdate {
         account_guid_hash: BalanceAccountGuidHash,
-        status: WhitelistStatus,
+        whitelist_status: Option<BooleanSetting>,
+        dapps_enabled: Option<BooleanSetting>,
     },
 
     /// 0  `[writable]` The multisig operation account
     /// 1. `[writable]` The wallet account
     /// 2. `[signer]` The rent collector account
-    FinalizeWhitelistStatusUpdate {
+    FinalizeAccountSettingsUpdate {
         account_guid_hash: BalanceAccountGuidHash,
-        status: WhitelistStatus,
+        whitelist_status: Option<BooleanSetting>,
+        dapps_enabled: Option<BooleanSetting>,
     },
 }
 
@@ -377,21 +381,25 @@ impl ProgramInstruction {
                     append_instruction(instruction, &mut buf);
                 }
             }
-            &ProgramInstruction::InitWhitelistStatusUpdate {
+            &ProgramInstruction::InitAccountSettingsUpdate {
                 ref account_guid_hash,
-                ref status,
+                ref whitelist_status,
+                ref dapps_enabled,
             } => {
                 buf.push(18);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
-                buf.push(status.to_u8());
+                pack_option(whitelist_status.as_ref(), &mut buf);
+                pack_option(dapps_enabled.as_ref(), &mut buf);
             }
-            &ProgramInstruction::FinalizeWhitelistStatusUpdate {
+            &ProgramInstruction::FinalizeAccountSettingsUpdate {
                 ref account_guid_hash,
-                ref status,
+                ref whitelist_status,
+                ref dapps_enabled,
             } => {
                 buf.push(19);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
-                buf.push(status.to_u8());
+                pack_option(whitelist_status.as_ref(), &mut buf);
+                pack_option(dapps_enabled.as_ref(), &mut buf);
             }
         }
         buf
@@ -420,8 +428,8 @@ impl ProgramInstruction {
             15 => Self::unpack_finalize_wallet_config_policy_update_instruction(rest)?,
             16 => Self::unpack_init_dapp_transaction_instruction(rest)?,
             17 => Self::unpack_finalize_dapp_transaction_instruction(rest)?,
-            18 => Self::unpack_init_whitelist_status_update_instruction(rest)?,
-            19 => Self::unpack_finalize_whitelist_status_update_instruction(rest)?,
+            18 => Self::unpack_init_account_settings_update_instruction(rest)?,
+            19 => Self::unpack_finalize_account_settings_update_instruction(rest)?,
             _ => return Err(ProgramError::InvalidInstructionData),
         })
     }
@@ -652,7 +660,7 @@ impl ProgramInstruction {
     ) -> Result<ProgramInstruction, ProgramError> {
         let iter = &mut bytes.into_iter();
         let account_guid_hash = unpack_account_guid_hash(
-            read_slice(iter, 32).ok_or(ProgramError::InvalidInstructionData)?,
+            utils::read_slice(iter, 32).ok_or(ProgramError::InvalidInstructionData)?,
         )?;
         Ok(Self::InitDAppTransaction {
             account_guid_hash,
@@ -665,7 +673,7 @@ impl ProgramInstruction {
     ) -> Result<ProgramInstruction, ProgramError> {
         let iter = &mut bytes.into_iter();
         let account_guid_hash = unpack_account_guid_hash(
-            read_slice(iter, 32).ok_or(ProgramError::InvalidInstructionData)?,
+            utils::read_slice(iter, 32).ok_or(ProgramError::InvalidInstructionData)?,
         )?;
         Ok(Self::FinalizeDAppTransaction {
             account_guid_hash,
@@ -673,21 +681,29 @@ impl ProgramInstruction {
         })
     }
 
-    fn unpack_init_whitelist_status_update_instruction(
+    fn unpack_init_account_settings_update_instruction(
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
-        Ok(Self::InitWhitelistStatusUpdate {
-            account_guid_hash: unpack_account_guid_hash(bytes)?,
-            status: WhitelistStatus::from_u8(bytes[32]),
+        let iter = &mut bytes.into_iter();
+        Ok(Self::InitAccountSettingsUpdate {
+            account_guid_hash: unpack_account_guid_hash(
+                utils::read_slice(iter, 32).ok_or(ProgramError::InvalidInstructionData)?,
+            )?,
+            whitelist_status: utils::unpack_option::<BooleanSetting>(iter)?,
+            dapps_enabled: utils::unpack_option::<BooleanSetting>(iter)?,
         })
     }
 
-    fn unpack_finalize_whitelist_status_update_instruction(
+    fn unpack_finalize_account_settings_update_instruction(
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
-        Ok(Self::FinalizeWhitelistStatusUpdate {
-            account_guid_hash: unpack_account_guid_hash(bytes)?,
-            status: WhitelistStatus::from_u8(bytes[32]),
+        let iter = &mut bytes.into_iter();
+        Ok(Self::FinalizeAccountSettingsUpdate {
+            account_guid_hash: unpack_account_guid_hash(
+                utils::read_slice(iter, 32).ok_or(ProgramError::InvalidInstructionData)?,
+            )?,
+            whitelist_status: utils::unpack_option::<BooleanSetting>(iter)?,
+            dapps_enabled: utils::unpack_option::<BooleanSetting>(iter)?,
         })
     }
 }
@@ -838,17 +854,7 @@ fn read_u16(iter: &mut Iter<u8>) -> Option<u16> {
 }
 
 fn read_fixed_size_array<'a, const SIZE: usize>(iter: &'a mut Iter<u8>) -> Option<&'a [u8; SIZE]> {
-    read_slice(iter, SIZE).and_then(|slice| slice.try_into().ok())
-}
-
-fn read_slice<'a>(iter: &'a mut Iter<u8>, size: usize) -> Option<&'a [u8]> {
-    let slice = iter.as_slice().get(0..size);
-    if slice.is_some() {
-        for _ in 0..size {
-            iter.next();
-        }
-    }
-    return slice;
+    utils::read_slice(iter, SIZE).and_then(|slice| slice.try_into().ok())
 }
 
 fn read_duration(iter: &mut Iter<u8>) -> Option<Duration> {
@@ -861,7 +867,7 @@ fn append_duration(duration: &Duration, dst: &mut Vec<u8>) {
 
 fn read_signers(iter: &mut Iter<u8>) -> Result<Vec<(SlotId<Signer>, Signer)>, ProgramError> {
     let signers_count = *read_u8(iter).ok_or(ProgramError::InvalidInstructionData)?;
-    read_slice(iter, usize::from(signers_count) * (1 + Signer::LEN))
+    utils::read_slice(iter, usize::from(signers_count) * (1 + Signer::LEN))
         .ok_or(ProgramError::InvalidInstructionData)?
         .chunks_exact(1 + Signer::LEN)
         .map(|chunk| {
@@ -890,7 +896,7 @@ fn read_instructions(iter: &mut Iter<u8>) -> Result<Vec<Instruction>, ProgramErr
 
 fn read_instruction(iter: &mut Iter<u8>) -> Result<Instruction, ProgramError> {
     let program_id = Pubkey::new(
-        read_slice(iter, 32)
+        utils::read_slice(iter, 32)
             .ok_or(ProgramError::InvalidInstructionData)?
             .into(),
     );
@@ -901,7 +907,7 @@ fn read_instruction(iter: &mut Iter<u8>) -> Result<Instruction, ProgramError> {
                 .ok_or(ProgramError::InvalidInstructionData)
                 .unwrap();
             let pubkey = Pubkey::new(
-                read_slice(iter, 32)
+                utils::read_slice(iter, 32)
                     .ok_or(ProgramError::InvalidInstructionData)
                     .unwrap()
                     .try_into()
@@ -916,7 +922,7 @@ fn read_instruction(iter: &mut Iter<u8>) -> Result<Instruction, ProgramError> {
         })
         .collect();
     let data_len = read_u16(iter).ok_or(ProgramError::InvalidInstructionData)?;
-    let data = read_slice(iter, data_len.try_into().unwrap())
+    let data = utils::read_slice(iter, data_len.try_into().unwrap())
         .ok_or(ProgramError::InvalidInstructionData)?
         .to_vec();
     Ok(Instruction {
@@ -949,7 +955,7 @@ fn read_address_book_entries(
     iter: &mut Iter<u8>,
 ) -> Result<Vec<(SlotId<AddressBookEntry>, AddressBookEntry)>, ProgramError> {
     let entries_count = *read_u8(iter).ok_or(ProgramError::InvalidInstructionData)?;
-    read_slice(
+    utils::read_slice(
         iter,
         usize::from(entries_count) * (1 + AddressBookEntry::LEN),
     )

--- a/src/model/address_book.rs
+++ b/src/model/address_book.rs
@@ -6,6 +6,7 @@ use solana_program::program_pack::{Pack, Sealed};
 use solana_program::pubkey::Pubkey;
 
 pub type AddressBook = Slots<AddressBookEntry, { Wallet::MAX_ADDRESS_BOOK_ENTRIES }>;
+pub type DAppBook = Slots<AddressBookEntry, { Wallet::MAX_DAPP_BOOK_ENTRIES }>;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Copy)]
 pub struct AddressBookEntryNameHash([u8; 32]);

--- a/src/model/balance_account.rs
+++ b/src/model/balance_account.rs
@@ -1,5 +1,5 @@
 use crate::model::address_book::{AddressBook, AddressBookEntry};
-use crate::model::multisig_op::WhitelistStatus;
+use crate::model::multisig_op::BooleanSetting;
 use crate::model::wallet::Approvers;
 use crate::utils::SlotFlags;
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
@@ -8,6 +8,9 @@ use solana_program::program_pack::{Pack, Sealed};
 use std::time::Duration;
 
 pub type AllowedDestinations = SlotFlags<AddressBookEntry, { AddressBook::FLAGS_STORAGE_SIZE }>;
+
+const WHITELIST_SETTING_BIT: u8 = 0;
+const DAPPS_SETTING_BIT: u8 = 1;
 
 #[derive(Debug, Clone, Eq, PartialEq, Copy)]
 pub struct BalanceAccountGuidHash([u8; 32]);
@@ -51,7 +54,8 @@ pub struct BalanceAccount {
     pub approval_timeout_for_transfer: Duration,
     pub transfer_approvers: Approvers,
     pub allowed_destinations: AllowedDestinations,
-    pub whitelist_status: WhitelistStatus,
+    pub whitelist_status: BooleanSetting,
+    pub dapps_enabled: BooleanSetting,
 }
 
 impl Sealed for BalanceAccount {}
@@ -63,7 +67,7 @@ impl Pack for BalanceAccount {
         8 + // approval_timeout_for_transfer
         Approvers::STORAGE_SIZE + // transfer approvers
         AllowedDestinations::STORAGE_SIZE +  // allowed destinations
-        1; // whitelist status
+        1; // boolean settings
 
     fn pack_into_slice(&self, dst: &mut [u8]) {
         let dst = array_mut_ref![dst, 0, BalanceAccount::LEN];
@@ -74,7 +78,7 @@ impl Pack for BalanceAccount {
             approval_timeout_for_transfer_dst,
             approvers_dst,
             allowed_destinations_dst,
-            whitelist_status_dst,
+            boolean_settings_dst,
         ) = mut_array_refs![
             dst,
             32,
@@ -95,7 +99,8 @@ impl Pack for BalanceAccount {
 
         approvers_dst.copy_from_slice(self.transfer_approvers.as_bytes());
         allowed_destinations_dst.copy_from_slice(self.allowed_destinations.as_bytes());
-        whitelist_status_dst[0] = self.whitelist_status.to_u8()
+        boolean_settings_dst[0] |= self.whitelist_status.to_u8() << WHITELIST_SETTING_BIT;
+        boolean_settings_dst[0] |= self.dapps_enabled.to_u8() << DAPPS_SETTING_BIT;
     }
 
     fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
@@ -107,7 +112,7 @@ impl Pack for BalanceAccount {
             approval_timeout_for_transfer_src,
             approvers_src,
             allowed_destinations_src,
-            whitelist_status_src,
+            boolean_settings_src,
         ) = array_refs![
             src,
             32,
@@ -128,14 +133,23 @@ impl Pack for BalanceAccount {
             )),
             transfer_approvers: Approvers::new(*approvers_src),
             allowed_destinations: AllowedDestinations::new(*allowed_destinations_src),
-            whitelist_status: WhitelistStatus::from_u8(whitelist_status_src[0]),
+            whitelist_status: BooleanSetting::from_u8(
+                boolean_settings_src[0] & (1 << WHITELIST_SETTING_BIT),
+            ),
+            dapps_enabled: BooleanSetting::from_u8(
+                boolean_settings_src[0] & (1 << DAPPS_SETTING_BIT),
+            ),
         })
     }
 }
 
 impl BalanceAccount {
     pub fn is_whitelist_disabled(&self) -> bool {
-        return self.whitelist_status == WhitelistStatus::Off;
+        return self.whitelist_status == BooleanSetting::Off;
+    }
+
+    pub fn are_dapps_disabled(&self) -> bool {
+        return self.dapps_enabled == BooleanSetting::Off;
     }
 
     pub fn has_whitelisted_destinations(&self) -> bool {

--- a/src/model/balance_account.rs
+++ b/src/model/balance_account.rs
@@ -54,7 +54,7 @@ pub struct BalanceAccount {
     pub approval_timeout_for_transfer: Duration,
     pub transfer_approvers: Approvers,
     pub allowed_destinations: AllowedDestinations,
-    pub whitelist_status: BooleanSetting,
+    pub whitelist_enabled: BooleanSetting,
     pub dapps_enabled: BooleanSetting,
 }
 
@@ -99,7 +99,7 @@ impl Pack for BalanceAccount {
 
         approvers_dst.copy_from_slice(self.transfer_approvers.as_bytes());
         allowed_destinations_dst.copy_from_slice(self.allowed_destinations.as_bytes());
-        boolean_settings_dst[0] |= self.whitelist_status.to_u8() << WHITELIST_SETTING_BIT;
+        boolean_settings_dst[0] |= self.whitelist_enabled.to_u8() << WHITELIST_SETTING_BIT;
         boolean_settings_dst[0] |= self.dapps_enabled.to_u8() << DAPPS_SETTING_BIT;
     }
 
@@ -133,7 +133,7 @@ impl Pack for BalanceAccount {
             )),
             transfer_approvers: Approvers::new(*approvers_src),
             allowed_destinations: AllowedDestinations::new(*allowed_destinations_src),
-            whitelist_status: BooleanSetting::from_u8(
+            whitelist_enabled: BooleanSetting::from_u8(
                 boolean_settings_src[0] & (1 << WHITELIST_SETTING_BIT),
             ),
             dapps_enabled: BooleanSetting::from_u8(
@@ -145,7 +145,7 @@ impl Pack for BalanceAccount {
 
 impl BalanceAccount {
     pub fn is_whitelist_disabled(&self) -> bool {
-        return self.whitelist_status == BooleanSetting::Off;
+        return self.whitelist_enabled == BooleanSetting::Off;
     }
 
     pub fn are_dapps_disabled(&self) -> bool {

--- a/src/model/multisig_op.rs
+++ b/src/model/multisig_op.rs
@@ -5,7 +5,7 @@ use crate::instruction::{
 use crate::model::balance_account::BalanceAccountGuidHash;
 use crate::model::signer::Signer;
 use crate::model::wallet::Wallet;
-use crate::utils::SlotId;
+use crate::utils::{pack_option, SlotId};
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
 use bitvec::macros::internal::funty::Fundamental;
 use bytes::BufMut;
@@ -125,23 +125,53 @@ impl SlotUpdateType {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 #[repr(u8)]
-pub enum WhitelistStatus {
+pub enum BooleanSetting {
     Off = 0,
     On = 1,
 }
 
-impl WhitelistStatus {
-    pub fn from_u8(value: u8) -> WhitelistStatus {
+impl BooleanSetting {
+    pub fn from_u8(value: u8) -> BooleanSetting {
         match value {
-            0 => WhitelistStatus::Off,
-            _ => WhitelistStatus::On,
+            0 => BooleanSetting::Off,
+            _ => BooleanSetting::On,
         }
     }
 
     pub fn to_u8(&self) -> u8 {
         match self {
-            WhitelistStatus::Off => 0,
-            WhitelistStatus::On => 1,
+            BooleanSetting::Off => 0,
+            BooleanSetting::On => 1,
+        }
+    }
+}
+
+impl Sealed for BooleanSetting {}
+
+impl Default for BooleanSetting {
+    fn default() -> Self {
+        BooleanSetting::Off
+    }
+}
+
+impl IsInitialized for BooleanSetting {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+}
+
+impl Pack for BooleanSetting {
+    const LEN: usize = 1;
+
+    fn pack_into_slice(&self, dst: &mut [u8]) {
+        dst[0] = self.to_u8();
+    }
+
+    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
+        if src.len() == 0 {
+            Err(ProgramError::InvalidInstructionData)
+        } else {
+            Ok(BooleanSetting::from_u8(src[0]))
         }
     }
 }
@@ -448,10 +478,11 @@ pub enum MultisigOpParams {
         account_guid_hash: BalanceAccountGuidHash,
         instructions: Vec<Instruction>,
     },
-    WhitelistStatusUpdate {
+    AccountSettingsUpdate {
         wallet_address: Pubkey,
         account_guid_hash: BalanceAccountGuidHash,
-        status: WhitelistStatus,
+        whitelist_status: Option<BooleanSetting>,
+        dapps_enabled: Option<BooleanSetting>,
     },
 }
 
@@ -608,17 +639,18 @@ impl MultisigOpParams {
                     .copy_from_slice(&update_bytes);
                 hash(&bytes)
             }
-            MultisigOpParams::WhitelistStatusUpdate {
+            MultisigOpParams::AccountSettingsUpdate {
                 wallet_address,
                 account_guid_hash,
-                status,
+                whitelist_status,
+                dapps_enabled,
             } => {
-                let mut bytes: Vec<u8> = Vec::new();
-                bytes.resize(1 + PUBKEY_BYTES + 32 + 1, 0);
-                bytes[0] = 8; // type code
-                bytes[1..33].copy_from_slice(&wallet_address.to_bytes());
-                bytes[33..65].copy_from_slice(account_guid_hash.to_bytes());
-                bytes[65] = status.to_u8();
+                let mut bytes: Vec<u8> = Vec::with_capacity(1 + PUBKEY_BYTES + 32 + 1);
+                bytes.push(8);
+                bytes.extend_from_slice(&wallet_address.to_bytes());
+                bytes.extend_from_slice(account_guid_hash.to_bytes());
+                pack_option(whitelist_status.as_ref(), &mut bytes);
+                pack_option(dapps_enabled.as_ref(), &mut bytes);
                 hash(&bytes)
             }
         }

--- a/src/model/multisig_op.rs
+++ b/src/model/multisig_op.rs
@@ -481,7 +481,7 @@ pub enum MultisigOpParams {
     AccountSettingsUpdate {
         wallet_address: Pubkey,
         account_guid_hash: BalanceAccountGuidHash,
-        whitelist_status: Option<BooleanSetting>,
+        whitelist_enabled: Option<BooleanSetting>,
         dapps_enabled: Option<BooleanSetting>,
     },
 }
@@ -642,14 +642,14 @@ impl MultisigOpParams {
             MultisigOpParams::AccountSettingsUpdate {
                 wallet_address,
                 account_guid_hash,
-                whitelist_status,
+                whitelist_enabled,
                 dapps_enabled,
             } => {
                 let mut bytes: Vec<u8> = Vec::with_capacity(1 + PUBKEY_BYTES + 32 + 2 + 2);
                 bytes.push(8);
                 bytes.extend_from_slice(&wallet_address.to_bytes());
                 bytes.extend_from_slice(account_guid_hash.to_bytes());
-                pack_option(whitelist_status.as_ref(), &mut bytes);
+                pack_option(whitelist_enabled.as_ref(), &mut bytes);
                 pack_option(dapps_enabled.as_ref(), &mut bytes);
                 hash(&bytes)
             }

--- a/src/model/multisig_op.rs
+++ b/src/model/multisig_op.rs
@@ -645,7 +645,7 @@ impl MultisigOpParams {
                 whitelist_status,
                 dapps_enabled,
             } => {
-                let mut bytes: Vec<u8> = Vec::with_capacity(1 + PUBKEY_BYTES + 32 + 1);
+                let mut bytes: Vec<u8> = Vec::with_capacity(1 + PUBKEY_BYTES + 32 + 2 + 2);
                 bytes.push(8);
                 bytes.extend_from_slice(&wallet_address.to_bytes());
                 bytes.extend_from_slice(account_guid_hash.to_bytes());

--- a/src/model/wallet.rs
+++ b/src/model/wallet.rs
@@ -1,10 +1,12 @@
 use crate::error::WalletError;
 use crate::instruction::{BalanceAccountUpdate, WalletConfigPolicyUpdate, WalletUpdate};
-use crate::model::address_book::{AddressBook, AddressBookEntry, AddressBookEntryNameHash};
+use crate::model::address_book::{
+    AddressBook, AddressBookEntry, AddressBookEntryNameHash, DAppBook,
+};
 use crate::model::balance_account::{
     AllowedDestinations, BalanceAccount, BalanceAccountGuidHash, BalanceAccountNameHash,
 };
-use crate::model::multisig_op::WhitelistStatus;
+use crate::model::multisig_op::BooleanSetting;
 use crate::model::signer::Signer;
 use crate::utils::{GetSlotIds, SlotFlags, SlotId, Slots};
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
@@ -32,6 +34,7 @@ pub struct Wallet {
     pub config_approvers: Approvers,
     pub balance_accounts: Vec<BalanceAccount>,
     pub config_policy_update_locked: bool,
+    pub dapp_book: DAppBook,
 }
 
 impl Sealed for Wallet {}
@@ -48,6 +51,7 @@ impl Wallet {
     pub const MAX_ADDRESS_BOOK_ENTRIES: usize = 128;
     pub const MIN_APPROVAL_TIMEOUT: Duration = Duration::from_secs(60);
     pub const MAX_APPROVAL_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24 * 365);
+    pub const MAX_DAPP_BOOK_ENTRIES: usize = 32;
 
     pub fn get_config_approvers_keys(&self) -> Vec<Pubkey> {
         self.get_approvers_keys(&self.config_approvers)
@@ -301,7 +305,8 @@ impl Wallet {
             approval_timeout_for_transfer: Duration::from_secs(0),
             transfer_approvers: Approvers::zero(),
             allowed_destinations: AllowedDestinations::zero(),
-            whitelist_status: WhitelistStatus::Off,
+            whitelist_status: BooleanSetting::Off,
+            dapps_enabled: BooleanSetting::Off,
         };
         self.balance_accounts.push(balance_account);
         self.update_balance_account(account_guid_hash, update)
@@ -319,7 +324,7 @@ impl Wallet {
     pub fn validate_whitelist_status_update(
         &self,
         account_guid_hash: &BalanceAccountGuidHash,
-        status: WhitelistStatus,
+        status: BooleanSetting,
     ) -> ProgramResult {
         let mut self_clone = self.clone();
         self_clone.update_whitelist_status(account_guid_hash, status)
@@ -328,10 +333,10 @@ impl Wallet {
     pub fn update_whitelist_status(
         &mut self,
         account_guid_hash: &BalanceAccountGuidHash,
-        status: WhitelistStatus,
+        status: BooleanSetting,
     ) -> ProgramResult {
         let balance_account_idx = self.get_balance_account_index(account_guid_hash)?;
-        if status == WhitelistStatus::Off {
+        if status == BooleanSetting::Off {
             if self.balance_accounts[balance_account_idx].has_whitelisted_destinations() {
                 msg!("Cannot turn whitelist status to off as there are whitelisted addresses");
                 return Err(ProgramError::InvalidArgument);
@@ -339,6 +344,17 @@ impl Wallet {
         }
 
         self.balance_accounts[balance_account_idx].whitelist_status = status;
+
+        Ok(())
+    }
+
+    pub fn update_dapps_enabled(
+        &mut self,
+        account_guid_hash: &BalanceAccountGuidHash,
+        enabled: BooleanSetting,
+    ) -> ProgramResult {
+        let balance_account_idx = self.get_balance_account_index(account_guid_hash)?;
+        self.balance_accounts[balance_account_idx].dapps_enabled = enabled;
 
         Ok(())
     }
@@ -463,6 +479,30 @@ impl Wallet {
         Ok(())
     }
 
+    fn add_dapp_book_entries(
+        &mut self,
+        entries_to_add: &Vec<(SlotId<AddressBookEntry>, AddressBookEntry)>,
+    ) -> ProgramResult {
+        if !self.dapp_book.can_be_inserted(entries_to_add) {
+            msg!("Failed to add dapp book entries: at least one of the provided slots is already taken");
+            return Err(ProgramError::InvalidArgument);
+        }
+        self.dapp_book.insert_many(entries_to_add);
+        Ok(())
+    }
+
+    fn remove_dapp_book_entries(
+        &mut self,
+        entries_to_remove: &Vec<(SlotId<AddressBookEntry>, AddressBookEntry)>,
+    ) -> ProgramResult {
+        if !self.dapp_book.can_be_removed(entries_to_remove) {
+            msg!("Failed to remove dapp book entries: at least one of the provided entries is not present in the config");
+            return Err(ProgramError::InvalidArgument);
+        }
+        self.dapp_book.remove_many(entries_to_remove);
+        Ok(())
+    }
+
     fn enable_config_approvers(
         &mut self,
         approvers: &Vec<(SlotId<Signer>, Signer)>,
@@ -567,7 +607,8 @@ impl Pack for Wallet {
         8 + // approval_timeout_for_config
         Approvers::STORAGE_SIZE + // config approvers
         1 + BalanceAccount::LEN * Wallet::MAX_BALANCE_ACCOUNTS + // balance accounts with size
-        1; // config_policy_update_locked
+        1 + // config_policy_update_locked
+        DAppBook::LEN;
 
     fn pack_into_slice(&self, dst: &mut [u8]) {
         let dst = array_mut_ref![dst, 0, Wallet::LEN];
@@ -582,6 +623,7 @@ impl Pack for Wallet {
             balance_accounts_count_dst,
             balance_accounts_dst,
             config_policy_update_locked_dst,
+            dapp_book_dst,
         ) = mut_array_refs![
             dst,
             1,
@@ -593,7 +635,8 @@ impl Pack for Wallet {
             Approvers::STORAGE_SIZE,
             1,
             BalanceAccount::LEN * Wallet::MAX_BALANCE_ACCOUNTS,
-            1
+            1,
+            DAppBook::LEN
         ];
 
         is_initialized_dst[0] = self.is_initialized as u8;
@@ -601,6 +644,7 @@ impl Pack for Wallet {
         self.signers.pack_into_slice(signers_dst);
         self.assistant.pack_into_slice(assistant_account_dst);
         self.address_book.pack_into_slice(address_book_dst);
+        self.dapp_book.pack_into_slice(dapp_book_dst);
 
         approvals_required_for_config_dst[0] = self.approvals_required_for_config;
         *approval_timeout_for_config_dst = self.approval_timeout_for_config.as_secs().to_le_bytes();
@@ -631,6 +675,7 @@ impl Pack for Wallet {
             balance_accounts_count,
             balance_accounts_src,
             config_policy_update_locked_src,
+            dapp_book_src,
         ) = array_refs![
             src,
             1,
@@ -642,7 +687,8 @@ impl Pack for Wallet {
             Approvers::STORAGE_SIZE,
             1,
             BalanceAccount::LEN * Wallet::MAX_BALANCE_ACCOUNTS,
-            1
+            1,
+            DAppBook::LEN
         ];
 
         let mut balance_accounts = Vec::with_capacity(Wallet::MAX_BALANCE_ACCOUNTS);
@@ -673,6 +719,7 @@ impl Pack for Wallet {
                 [1] => true,
                 _ => return Err(ProgramError::InvalidAccountData),
             },
+            dapp_book: DAppBook::unpack_from_slice(dapp_book_src)?,
         })
     }
 }

--- a/src/model/wallet.rs
+++ b/src/model/wallet.rs
@@ -305,7 +305,7 @@ impl Wallet {
             approval_timeout_for_transfer: Duration::from_secs(0),
             transfer_approvers: Approvers::zero(),
             allowed_destinations: AllowedDestinations::zero(),
-            whitelist_status: BooleanSetting::Off,
+            whitelist_enabled: BooleanSetting::Off,
             dapps_enabled: BooleanSetting::Off,
         };
         self.balance_accounts.push(balance_account);
@@ -321,16 +321,16 @@ impl Wallet {
         self_clone.update_balance_account(account_guid_hash, update)
     }
 
-    pub fn validate_whitelist_status_update(
+    pub fn validate_whitelist_enabled_update(
         &self,
         account_guid_hash: &BalanceAccountGuidHash,
         status: BooleanSetting,
     ) -> ProgramResult {
         let mut self_clone = self.clone();
-        self_clone.update_whitelist_status(account_guid_hash, status)
+        self_clone.update_whitelist_enabled(account_guid_hash, status)
     }
 
-    pub fn update_whitelist_status(
+    pub fn update_whitelist_enabled(
         &mut self,
         account_guid_hash: &BalanceAccountGuidHash,
         status: BooleanSetting,
@@ -343,7 +343,7 @@ impl Wallet {
             }
         }
 
-        self.balance_accounts[balance_account_idx].whitelist_status = status;
+        self.balance_accounts[balance_account_idx].whitelist_enabled = status;
 
         Ok(())
     }
@@ -389,7 +389,7 @@ impl Wallet {
 
         if !update.add_allowed_destinations.is_empty() && balance_account.is_whitelist_disabled() {
             msg!("Cannot add destinations when whitelisting status is Off");
-            return Err(WalletError::WhitelistingStatusOff.into());
+            return Err(WalletError::WhitelistDisabled.into());
         }
 
         let approvers_count_after_update = balance_account.transfer_approvers.count_enabled();

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -21,7 +21,7 @@ use crate::handlers::utils::{
     finalize_multisig_op, get_clock_from_next_account, next_program_account_info,
     start_multisig_config_op, start_multisig_transfer_op, validate_balance_account_and_get_seed,
 };
-use crate::handlers::{wallet_config_policy_update_handler, whitelist_status_update_handler};
+use crate::handlers::{account_settings_update_handler, wallet_config_policy_update_handler};
 use crate::instruction::{BalanceAccountUpdate, ProgramInstruction, WalletUpdate};
 use crate::model::address_book::AddressBookEntryNameHash;
 use crate::model::balance_account::BalanceAccountGuidHash;
@@ -200,24 +200,28 @@ impl Processor {
                 instructions,
             ),
 
-            ProgramInstruction::InitWhitelistStatusUpdate {
+            ProgramInstruction::InitAccountSettingsUpdate {
                 account_guid_hash,
-                status,
-            } => whitelist_status_update_handler::init(
+                whitelist_status,
+                dapps_enabled,
+            } => account_settings_update_handler::init(
                 program_id,
                 &accounts,
                 &account_guid_hash,
-                status,
+                whitelist_status,
+                dapps_enabled,
             ),
 
-            ProgramInstruction::FinalizeWhitelistStatusUpdate {
+            ProgramInstruction::FinalizeAccountSettingsUpdate {
                 account_guid_hash,
-                status,
-            } => whitelist_status_update_handler::finalize(
+                whitelist_status,
+                dapps_enabled,
+            } => account_settings_update_handler::finalize(
                 program_id,
                 &accounts,
                 &account_guid_hash,
-                status,
+                whitelist_status,
+                dapps_enabled,
             ),
         }
     }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -202,25 +202,25 @@ impl Processor {
 
             ProgramInstruction::InitAccountSettingsUpdate {
                 account_guid_hash,
-                whitelist_status,
+                whitelist_enabled,
                 dapps_enabled,
             } => account_settings_update_handler::init(
                 program_id,
                 &accounts,
                 &account_guid_hash,
-                whitelist_status,
+                whitelist_enabled,
                 dapps_enabled,
             ),
 
             ProgramInstruction::FinalizeAccountSettingsUpdate {
                 account_guid_hash,
-                whitelist_status,
+                whitelist_enabled,
                 dapps_enabled,
             } => account_settings_update_handler::finalize(
                 program_id,
                 &accounts,
                 &account_guid_hash,
-                whitelist_status,
+                whitelist_enabled,
                 dapps_enabled,
             ),
         }

--- a/tests/common/instructions.rs
+++ b/tests/common/instructions.rs
@@ -11,7 +11,7 @@ use strike_wallet::instruction::{
 use strike_wallet::model::address_book::{AddressBookEntry, AddressBookEntryNameHash};
 use strike_wallet::model::balance_account::{BalanceAccountGuidHash, BalanceAccountNameHash};
 use strike_wallet::model::multisig_op::{
-    ApprovalDisposition, SlotUpdateType, WhitelistStatus, WrapDirection,
+    ApprovalDisposition, BooleanSetting, SlotUpdateType, WrapDirection,
 };
 use strike_wallet::model::signer::Signer;
 use strike_wallet::utils::SlotId;
@@ -663,37 +663,41 @@ pub fn finalize_dapp_transaction(
     }
 }
 
-pub fn init_whitelist_status_update(
+pub fn init_account_settings_update(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
     multisig_op_account: &Pubkey,
     assistant_account: &Pubkey,
     account_guid_hash: BalanceAccountGuidHash,
-    status: WhitelistStatus,
+    whitelist_status: Option<BooleanSetting>,
+    dapps_enabled: Option<BooleanSetting>,
 ) -> Instruction {
     init_multisig_op(
         program_id,
         wallet_account,
         multisig_op_account,
         assistant_account,
-        ProgramInstruction::InitWhitelistStatusUpdate {
+        ProgramInstruction::InitAccountSettingsUpdate {
             account_guid_hash,
-            status,
+            whitelist_status,
+            dapps_enabled,
         },
     )
 }
 
-pub fn finalize_whitelist_status_update(
+pub fn finalize_account_settings_update(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
     multisig_op_account: &Pubkey,
     rent_collector_account: &Pubkey,
     account_guid_hash: BalanceAccountGuidHash,
-    status: WhitelistStatus,
+    whitelist_status: Option<BooleanSetting>,
+    dapps_enabled: Option<BooleanSetting>,
 ) -> Instruction {
-    let data = ProgramInstruction::FinalizeWhitelistStatusUpdate {
+    let data = ProgramInstruction::FinalizeAccountSettingsUpdate {
         account_guid_hash,
-        status,
+        whitelist_status,
+        dapps_enabled,
     }
     .borrow()
     .pack();

--- a/tests/common/instructions.rs
+++ b/tests/common/instructions.rs
@@ -679,7 +679,7 @@ pub fn init_account_settings_update(
         assistant_account,
         ProgramInstruction::InitAccountSettingsUpdate {
             account_guid_hash,
-            whitelist_status,
+            whitelist_enabled: whitelist_status,
             dapps_enabled,
         },
     )
@@ -696,7 +696,7 @@ pub fn finalize_account_settings_update(
 ) -> Instruction {
     let data = ProgramInstruction::FinalizeAccountSettingsUpdate {
         account_guid_hash,
-        whitelist_status,
+        whitelist_enabled: whitelist_status,
         dapps_enabled,
     }
     .borrow()

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -1,10 +1,9 @@
 use crate::common::instructions;
 use crate::common::instructions::{
-    finalize_balance_account_update, finalize_update_signer,
-    finalize_wallet_config_policy_update_instruction, finalize_whitelist_status_update,
+    finalize_account_settings_update, finalize_balance_account_update, finalize_update_signer,
+    finalize_wallet_config_policy_update_instruction, init_account_settings_update,
     init_balance_account_creation, init_balance_account_update, init_transfer, init_update_signer,
-    init_wallet_config_policy_update_instruction, init_wallet_update, init_whitelist_status_update,
-    set_approval_disposition,
+    init_wallet_config_policy_update_instruction, init_wallet_update, set_approval_disposition,
 };
 use arrayref::array_ref;
 use itertools::Itertools;
@@ -21,11 +20,13 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use strike_wallet::instruction::{BalanceAccountUpdate, WalletConfigPolicyUpdate, WalletUpdate};
-use strike_wallet::model::address_book::{AddressBook, AddressBookEntry, AddressBookEntryNameHash};
+use strike_wallet::model::address_book::{
+    AddressBook, AddressBookEntry, AddressBookEntryNameHash, DAppBook,
+};
 use strike_wallet::model::balance_account::{BalanceAccountGuidHash, BalanceAccountNameHash};
 use strike_wallet::model::multisig_op::{
-    ApprovalDisposition, ApprovalDispositionRecord, MultisigOp, MultisigOpParams,
-    OperationDisposition, SlotUpdateType, WhitelistStatus, WrapDirection,
+    ApprovalDisposition, ApprovalDispositionRecord, BooleanSetting, MultisigOp, MultisigOpParams,
+    OperationDisposition, SlotUpdateType, WrapDirection,
 };
 use strike_wallet::model::signer::Signer;
 use strike_wallet::model::wallet::{Approvers, Signers};
@@ -437,6 +438,7 @@ pub async fn setup_wallet_update_test() -> WalletUpdateContext {
             config_approvers: Approvers::from_enabled_vec(vec![SlotId::new(1), SlotId::new(2)]),
             balance_accounts: wallet.balance_accounts,
             config_policy_update_locked: false,
+            dapp_book: DAppBook::from_vec(vec![]),
         },
         assistant_account,
     }
@@ -624,9 +626,10 @@ pub async fn update_signer(
     );
 }
 
-pub async fn whitelist_status_update(
+pub async fn account_settings_update(
     context: &mut BalanceAccountTestContext,
-    status: WhitelistStatus,
+    whitelist_status: Option<BooleanSetting>,
+    dapps_enabled: Option<BooleanSetting>,
     expected_error: Option<InstructionError>,
 ) {
     let rent = context.banks_client.get_rent().await.unwrap();
@@ -641,13 +644,14 @@ pub async fn whitelist_status_update(
                 MultisigOp::LEN as u64,
                 &context.program_id,
             ),
-            init_whitelist_status_update(
+            init_account_settings_update(
                 &context.program_id,
                 &context.wallet_account.pubkey(),
                 &multisig_op_account.pubkey(),
                 &context.assistant_account.pubkey(),
                 context.balance_account_guid_hash,
-                status,
+                whitelist_status,
+                dapps_enabled,
             ),
         ],
         Some(&context.payer.pubkey()),
@@ -711,10 +715,11 @@ pub async fn whitelist_status_update(
 
     assert_eq!(
         multisig_op.params_hash,
-        MultisigOpParams::WhitelistStatusUpdate {
+        MultisigOpParams::AccountSettingsUpdate {
             wallet_address: context.wallet_account.pubkey(),
             account_guid_hash: context.balance_account_guid_hash,
-            status
+            whitelist_status,
+            dapps_enabled,
         }
         .hash()
     );
@@ -749,13 +754,14 @@ pub async fn whitelist_status_update(
 
     // finalize the multisig op
     let finalize_transaction = Transaction::new_signed_with_payer(
-        &[finalize_whitelist_status_update(
+        &[finalize_account_settings_update(
             &context.program_id,
             &context.wallet_account.pubkey(),
             &multisig_op_account.pubkey(),
             &context.payer.pubkey(),
             context.balance_account_guid_hash,
-            status,
+            whitelist_status,
+            dapps_enabled,
         )],
         Some(&context.payer.pubkey()),
         &[&context.payer],
@@ -799,7 +805,7 @@ pub async fn whitelist_status_update(
 
 pub async fn verify_whitelist_status(
     context: &mut BalanceAccountTestContext,
-    expected_status: WhitelistStatus,
+    expected_status: BooleanSetting,
     expected_whitelist_count: usize,
 ) {
     let wallet = get_wallet(&mut context.banks_client, &context.wallet_account.pubkey()).await;
@@ -812,6 +818,18 @@ pub async fn verify_whitelist_status(
         account.allowed_destinations.count_enabled(),
         expected_whitelist_count
     );
+}
+
+pub async fn verify_dapps_enabled(
+    context: &mut BalanceAccountTestContext,
+    expected_enabled: BooleanSetting,
+) {
+    let wallet = get_wallet(&mut context.banks_client, &context.wallet_account.pubkey()).await;
+    let account = wallet
+        .get_balance_account(&context.balance_account_guid_hash)
+        .unwrap();
+
+    assert_eq!(account.dapps_enabled, expected_enabled);
 }
 
 pub async fn approve_or_deny_n_of_n_multisig_op(

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -718,7 +718,7 @@ pub async fn account_settings_update(
         MultisigOpParams::AccountSettingsUpdate {
             wallet_address: context.wallet_account.pubkey(),
             account_guid_hash: context.balance_account_guid_hash,
-            whitelist_status,
+            whitelist_enabled: whitelist_status,
             dapps_enabled,
         }
         .hash()
@@ -813,7 +813,7 @@ pub async fn verify_whitelist_status(
         .get_balance_account(&context.balance_account_guid_hash)
         .unwrap();
 
-    assert_eq!(account.whitelist_status, expected_status);
+    assert_eq!(account.whitelist_enabled, expected_status);
     assert_eq!(
         account.allowed_destinations.count_enabled(),
         expected_whitelist_count

--- a/tests/wallet_config_policy_update_tests.rs
+++ b/tests/wallet_config_policy_update_tests.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test-bpf")]
 mod common;
-pub use common::utils::*;
 pub use common::instructions::*;
+pub use common::utils::*;
 
 pub use common::utils;
 use solana_program::instruction::InstructionError;
@@ -129,6 +129,7 @@ async fn wallet_config_policy_update() {
             config_approvers: Approvers::from_enabled_vec(vec![SlotId::new(1), SlotId::new(2)]),
             balance_accounts: wallet.balance_accounts,
             config_policy_update_locked: false,
+            dapp_book: wallet.dapp_book,
         },
         get_wallet(&mut context.banks_client, &wallet_account.pubkey()).await
     );

--- a/tests/whitelist_status_update_tests.rs
+++ b/tests/whitelist_status_update_tests.rs
@@ -30,7 +30,7 @@ async fn test_whitelist_status() {
         &mut context,
         vec![(SlotId::new(0), destination_to_add)],
         vec![],
-        Some(Custom(WalletError::WhitelistingStatusOff as u32)),
+        Some(Custom(WalletError::WhitelistDisabled as u32)),
     )
     .await;
 

--- a/tests/whitelist_status_update_tests.rs
+++ b/tests/whitelist_status_update_tests.rs
@@ -10,7 +10,7 @@ use solana_program_test::tokio;
 use solana_sdk::transaction::TransactionError;
 use std::borrow::BorrowMut;
 use strike_wallet::error::WalletError;
-use strike_wallet::model::multisig_op::WhitelistStatus;
+use strike_wallet::model::multisig_op::BooleanSetting;
 use strike_wallet::utils::SlotId;
 
 #[tokio::test]
@@ -18,7 +18,7 @@ async fn test_whitelist_status() {
     let (mut context, balance_account) = setup_balance_account_tests_and_finalize(None).await;
 
     // status is off by default
-    verify_whitelist_status(&mut context, WhitelistStatus::Off, 0).await;
+    verify_whitelist_status(&mut context, BooleanSetting::Off, 0).await;
 
     // transfer should go through
     let (_, result) = setup_transfer_test(context.borrow_mut(), &balance_account, None, None).await;
@@ -35,8 +35,8 @@ async fn test_whitelist_status() {
     .await;
 
     // turn whitelisting on should be able to add destination now
-    whitelist_status_update(&mut context, WhitelistStatus::On, None).await;
-    verify_whitelist_status(&mut context, WhitelistStatus::On, 0).await;
+    account_settings_update(&mut context, Some(BooleanSetting::On), None, None).await;
+    verify_whitelist_status(&mut context, BooleanSetting::On, 0).await;
     modify_whitelist(
         &mut context,
         vec![(SlotId::new(0), destination_to_add)],
@@ -46,7 +46,13 @@ async fn test_whitelist_status() {
     .await;
 
     // try to turn it off - should fail since there are whitelisted destinations
-    whitelist_status_update(&mut context, WhitelistStatus::Off, Some(InvalidArgument)).await;
+    account_settings_update(
+        &mut context,
+        Some(BooleanSetting::Off),
+        None,
+        Some(InvalidArgument),
+    )
+    .await;
 
     // remove a whitelisted destination, status should still be On even though whitelist is empty
     let destination_to_remove = context.allowed_destination;
@@ -58,7 +64,7 @@ async fn test_whitelist_status() {
     )
     .await;
 
-    verify_whitelist_status(&mut context, WhitelistStatus::On, 0).await;
+    verify_whitelist_status(&mut context, BooleanSetting::On, 0).await;
 
     // make sure transfer fails
     let (_, result) = setup_transfer_test(context.borrow_mut(), &balance_account, None, None).await;
@@ -68,12 +74,12 @@ async fn test_whitelist_status() {
     );
 
     // explicitly turn it off and verify transfer succeeds
-    whitelist_status_update(&mut context, WhitelistStatus::Off, None).await;
-    verify_whitelist_status(&mut context, WhitelistStatus::Off, 0).await;
+    account_settings_update(&mut context, Some(BooleanSetting::Off), None, None).await;
+    verify_whitelist_status(&mut context, BooleanSetting::Off, 0).await;
     let (_, result) = setup_transfer_test(context.borrow_mut(), &balance_account, None, None).await;
     result.unwrap();
 
     // explicitly turn it on
-    whitelist_status_update(&mut context, WhitelistStatus::On, None).await;
-    verify_whitelist_status(&mut context, WhitelistStatus::On, 0).await;
+    account_settings_update(&mut context, Some(BooleanSetting::On), None, None).await;
+    verify_whitelist_status(&mut context, BooleanSetting::On, 0).await;
 }


### PR DESCRIPTION
## Description

Added a `dapps_enabled` setting to the balance account state.
Changed the `WhitelistStatusUpdate` multisig op to be `AccountSettingsUpdate`. Added generic functionality for packing/unpacking Option<T> for T some Pack-able type, and used it so that either, both, or neither of the whitelist status or dapps enabled settings can be changed in the instruction.

## Motivation and Context
We need to add "dapps_enabled" setting to account, and are likely to add more settings in the future, so a more generic mechanism is called for instead of having separate approvals / instructions for each setting.

## How Has This Been Tested?
Existing unit tests all pass, and added a test that dapps require dapps_enabled to be set.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

