### PR TITLE
implement dapp book management, and dapps check address book

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,9 @@
 ## Types of changes
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
 - [ ] Bug fix breaking (fix that would cause existing functionality to change)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] New feature breaking (change which adds functionality and causes existing functionality to change)
 
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,6 +87,8 @@ pub enum WalletError {
     /// Unknown Signer
     #[error("Unknown Signer")]
     UnknownSigner,
+    #[error("DApp Not Allowed")]
+    DAppNotAllowed,
 }
 
 impl From<WalletError> for ProgramError {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,4 +1,5 @@
 pub mod account_settings_update_handler;
+pub mod dapp_book_update_handler;
 pub mod dapp_transaction_handler;
 pub mod utils;
 pub mod wallet_config_policy_update_handler;

--- a/src/handlers/dapp_book_update_handler.rs
+++ b/src/handlers/dapp_book_update_handler.rs
@@ -2,8 +2,8 @@ use crate::handlers::utils::{
     finalize_multisig_op, get_clock_from_next_account, next_program_account_info,
     start_multisig_config_op,
 };
-use crate::model::balance_account::BalanceAccountGuidHash;
-use crate::model::multisig_op::{BooleanSetting, MultisigOpParams};
+use crate::instruction::DAppBookUpdate;
+use crate::model::multisig_op::MultisigOpParams;
 use crate::model::wallet::Wallet;
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
@@ -13,9 +13,7 @@ use solana_program::pubkey::Pubkey;
 pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    account_guid_hash: &BalanceAccountGuidHash,
-    whitelist_enabled: Option<BooleanSetting>,
-    dapps_enabled: Option<BooleanSetting>,
+    update: &DAppBookUpdate,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
     let multisig_op_account_info = next_program_account_info(accounts_iter, program_id)?;
@@ -24,30 +22,29 @@ pub fn init(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
+
     wallet.validate_config_initiator(initiator_account_info)?;
-    if let Some(status) = whitelist_enabled {
-        wallet.validate_whitelist_enabled_update(account_guid_hash, status)?;
-    }
+    wallet.validate_dapp_book_update(update)?;
 
     start_multisig_config_op(
         &multisig_op_account_info,
         &wallet,
         clock,
-        MultisigOpParams::UpdateAccountSettings {
+        MultisigOpParams::UpdateDAppBook {
             wallet_address: *wallet_account_info.key,
-            account_guid_hash: *account_guid_hash,
-            whitelist_enabled,
-            dapps_enabled,
+            update: update.clone(),
         },
-    )
+    )?;
+
+    Wallet::pack(wallet, &mut wallet_account_info.data.borrow_mut())?;
+
+    Ok(())
 }
 
 pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    account_guid_hash: &BalanceAccountGuidHash,
-    whitelist_enabled: Option<BooleanSetting>,
-    dapps_enabled: Option<BooleanSetting>,
+    update: &DAppBookUpdate,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
     let multisig_op_account_info = next_program_account_info(accounts_iter, program_id)?;
@@ -55,26 +52,23 @@ pub fn finalize(
     let account_to_return_rent_to = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
 
+    let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow_mut())?;
+
     finalize_multisig_op(
         &multisig_op_account_info,
         &account_to_return_rent_to,
         clock,
-        MultisigOpParams::UpdateAccountSettings {
+        MultisigOpParams::UpdateDAppBook {
             wallet_address: *wallet_account_info.key,
-            account_guid_hash: *account_guid_hash,
-            whitelist_enabled,
-            dapps_enabled,
+            update: update.clone(),
         },
         || -> ProgramResult {
-            let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow_mut())?;
-            if let Some(status) = whitelist_enabled {
-                wallet.update_whitelist_enabled(&account_guid_hash, status)?;
-            }
-            if let Some(enabled) = dapps_enabled {
-                wallet.update_dapps_enabled(&account_guid_hash, enabled)?;
-            }
-            Wallet::pack(wallet, &mut wallet_account_info.data.borrow_mut())?;
+            wallet.update_dapp_book(update)?;
             Ok(())
         },
-    )
+    )?;
+
+    Wallet::pack(wallet, &mut wallet_account_info.data.borrow_mut())?;
+
+    Ok(())
 }

--- a/src/handlers/dapp_transaction_handler.rs
+++ b/src/handlers/dapp_transaction_handler.rs
@@ -42,7 +42,7 @@ pub fn init(
     wallet.validate_transfer_initiator(balance_account, initiator_account_info)?;
 
     if !balance_account.is_whitelist_disabled() {
-        if !wallet.clone().dapp_allowed(dapp) {
+        if !wallet.dapp_allowed(dapp) {
             return Err(WalletError::DAppNotAllowed.into());
         }
     }

--- a/src/handlers/dapp_transaction_handler.rs
+++ b/src/handlers/dapp_transaction_handler.rs
@@ -5,6 +5,7 @@ use crate::handlers::utils::{
     calculate_expires, collect_remaining_balance, get_clock_from_next_account,
     next_program_account_info, validate_balance_account_and_get_seed,
 };
+use crate::model::address_book::AddressBookEntry;
 use crate::model::balance_account::BalanceAccountGuidHash;
 use crate::model::multisig_op::{MultisigOp, MultisigOpParams};
 use crate::model::wallet::Wallet;
@@ -22,6 +23,7 @@ pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     account_guid_hash: &BalanceAccountGuidHash,
+    dapp: AddressBookEntry,
     instructions: Vec<Instruction>,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
@@ -39,6 +41,16 @@ pub fn init(
 
     wallet.validate_transfer_initiator(balance_account, initiator_account_info)?;
 
+    msg!("here 1");
+    if !balance_account.is_whitelist_disabled() {
+        msg!("here 2");
+        // check that the specified dapp program id is in the dapp whitelist
+        if wallet.dapp_book.find_id(&dapp).is_none() {
+            return Err(WalletError::DAppNotAllowed.into());
+        }
+    }
+    msg!("here 3");
+
     let mut multisig_op = MultisigOp::unpack_unchecked(&multisig_op_account_info.data.borrow())?;
     multisig_op.init(
         wallet.get_transfer_approvers_keys(balance_account),
@@ -51,6 +63,7 @@ pub fn init(
         MultisigOpParams::DAppTransaction {
             wallet_address: *wallet_account_info.key,
             account_guid_hash: *account_guid_hash,
+            dapp,
             instructions,
         },
     )?;
@@ -145,6 +158,7 @@ pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     account_guid_hash: &BalanceAccountGuidHash,
+    dapp: AddressBookEntry,
     instructions: &Vec<Instruction>,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
@@ -164,6 +178,7 @@ pub fn finalize(
         wallet_address: *wallet_account_info.key,
         account_guid_hash: *account_guid_hash,
         instructions: instructions.clone(),
+        dapp,
     };
 
     const NOT_FINAL: u32 = WalletError::TransferDispositionNotFinal as u32;

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -10,7 +10,7 @@ use solana_program::program_error::ProgramError;
 use solana_program::program_pack::Pack;
 use solana_program::{instruction::AccountMeta, instruction::Instruction, pubkey::Pubkey};
 
-use crate::model::address_book::{AddressBookEntry, AddressBookEntryNameHash};
+use crate::model::address_book::{AddressBookEntry, AddressBookEntryNameHash, DAppBookEntry};
 use crate::model::balance_account::{BalanceAccountGuidHash, BalanceAccountNameHash};
 use crate::model::multisig_op::{
     ApprovalDisposition, BooleanSetting, SlotUpdateType, WrapDirection,
@@ -184,7 +184,7 @@ pub enum ProgramInstruction {
     InitDAppTransaction {
         account_guid_hash: BalanceAccountGuidHash,
         instructions: Vec<Instruction>,
-        dapp: AddressBookEntry,
+        dapp: DAppBookEntry,
     },
 
     /// 0. `[writable]` The multisig operation account
@@ -195,7 +195,7 @@ pub enum ProgramInstruction {
     FinalizeDAppTransaction {
         account_guid_hash: BalanceAccountGuidHash,
         instructions: Vec<Instruction>,
-        dapp: AddressBookEntry,
+        dapp: DAppBookEntry,
     },
 
     /// 0  `[writable]` The multisig operation account
@@ -380,7 +380,7 @@ impl ProgramInstruction {
             } => {
                 buf.push(16);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
-                let mut buf2 = vec![0; AddressBookEntry::LEN];
+                let mut buf2 = vec![0; DAppBookEntry::LEN];
                 dapp.pack_into_slice(buf2.as_mut_slice());
                 buf.extend_from_slice(&buf2[..]);
                 buf.put_u16_le(instructions.len() as u16);
@@ -395,7 +395,7 @@ impl ProgramInstruction {
             } => {
                 buf.push(17);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
-                let mut buf2 = vec![0; AddressBookEntry::LEN];
+                let mut buf2 = vec![0; DAppBookEntry::LEN];
                 dapp.pack_into_slice(buf2.as_mut_slice());
                 buf.extend_from_slice(&buf2[..]);
                 buf.put_u16_le(instructions.len() as u16);
@@ -698,8 +698,8 @@ impl ProgramInstruction {
         let account_guid_hash = unpack_account_guid_hash(
             utils::read_slice(iter, 32).ok_or(ProgramError::InvalidInstructionData)?,
         )?;
-        let dapp = AddressBookEntry::unpack_from_slice(
-            utils::read_slice(iter, AddressBookEntry::LEN)
+        let dapp = DAppBookEntry::unpack_from_slice(
+            utils::read_slice(iter, DAppBookEntry::LEN)
                 .ok_or(ProgramError::InvalidInstructionData)?,
         )?;
         Ok(Self::InitDAppTransaction {
@@ -716,8 +716,8 @@ impl ProgramInstruction {
         let account_guid_hash = unpack_account_guid_hash(
             utils::read_slice(iter, 32).ok_or(ProgramError::InvalidInstructionData)?,
         )?;
-        let dapp = AddressBookEntry::unpack_from_slice(
-            utils::read_slice(iter, AddressBookEntry::LEN)
+        let dapp = DAppBookEntry::unpack_from_slice(
+            utils::read_slice(iter, DAppBookEntry::LEN)
                 .ok_or(ProgramError::InvalidInstructionData)?,
         )?;
         Ok(Self::FinalizeDAppTransaction {
@@ -909,8 +909,8 @@ impl BalanceAccountUpdate {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DAppBookUpdate {
-    pub add_dapps: Vec<(SlotId<AddressBookEntry>, AddressBookEntry)>,
-    pub remove_dapps: Vec<(SlotId<AddressBookEntry>, AddressBookEntry)>,
+    pub add_dapps: Vec<(SlotId<DAppBookEntry>, DAppBookEntry)>,
+    pub remove_dapps: Vec<(SlotId<DAppBookEntry>, DAppBookEntry)>,
 }
 
 impl DAppBookUpdate {

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -184,6 +184,7 @@ pub enum ProgramInstruction {
     InitDAppTransaction {
         account_guid_hash: BalanceAccountGuidHash,
         instructions: Vec<Instruction>,
+        dapp: AddressBookEntry,
     },
 
     /// 0. `[writable]` The multisig operation account
@@ -194,6 +195,7 @@ pub enum ProgramInstruction {
     FinalizeDAppTransaction {
         account_guid_hash: BalanceAccountGuidHash,
         instructions: Vec<Instruction>,
+        dapp: AddressBookEntry,
     },
 
     /// 0  `[writable]` The multisig operation account
@@ -214,6 +216,18 @@ pub enum ProgramInstruction {
         whitelist_enabled: Option<BooleanSetting>,
         dapps_enabled: Option<BooleanSetting>,
     },
+
+    /// 0. `[writable]` The multisig operation account
+    /// 1. `[]` The wallet account
+    /// 2. `[signer]` The initiator account (either the transaction assistant or an approver)
+    /// 3. `[]` The sysvar clock account
+    InitDAppBookUpdate { update: DAppBookUpdate },
+
+    /// 0. `[writable]` The multisig operation account
+    /// 1. `[writable]` The wallet account
+    /// 2. `[signer]` The rent collector account
+    /// 3. `[]` The sysvar clock account
+    FinalizeDAppBookUpdate { update: DAppBookUpdate },
 }
 
 impl ProgramInstruction {
@@ -361,10 +375,14 @@ impl ProgramInstruction {
             }
             &ProgramInstruction::InitDAppTransaction {
                 ref account_guid_hash,
+                ref dapp,
                 ref instructions,
             } => {
                 buf.push(16);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
+                let mut buf2 = vec![0; AddressBookEntry::LEN];
+                dapp.pack_into_slice(buf2.as_mut_slice());
+                buf.extend_from_slice(&buf2[..]);
                 buf.put_u16_le(instructions.len() as u16);
                 for instruction in instructions.iter() {
                     append_instruction(instruction, &mut buf);
@@ -372,10 +390,14 @@ impl ProgramInstruction {
             }
             &ProgramInstruction::FinalizeDAppTransaction {
                 ref account_guid_hash,
+                ref dapp,
                 ref instructions,
             } => {
                 buf.push(17);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
+                let mut buf2 = vec![0; AddressBookEntry::LEN];
+                dapp.pack_into_slice(buf2.as_mut_slice());
+                buf.extend_from_slice(&buf2[..]);
                 buf.put_u16_le(instructions.len() as u16);
                 for instruction in instructions.iter() {
                     append_instruction(instruction, &mut buf);
@@ -400,6 +422,18 @@ impl ProgramInstruction {
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
                 pack_option(whitelist_enabled.as_ref(), &mut buf);
                 pack_option(dapps_enabled.as_ref(), &mut buf);
+            }
+            &ProgramInstruction::InitDAppBookUpdate { ref update } => {
+                buf.push(20);
+                let mut update_bytes: Vec<u8> = Vec::new();
+                update.pack(&mut update_bytes);
+                buf.extend_from_slice(&update_bytes);
+            }
+            &ProgramInstruction::FinalizeDAppBookUpdate { ref update } => {
+                buf.push(21);
+                let mut update_bytes: Vec<u8> = Vec::new();
+                update.pack(&mut update_bytes);
+                buf.extend_from_slice(&update_bytes);
             }
         }
         buf
@@ -430,6 +464,8 @@ impl ProgramInstruction {
             17 => Self::unpack_finalize_dapp_transaction_instruction(rest)?,
             18 => Self::unpack_init_account_settings_update_instruction(rest)?,
             19 => Self::unpack_finalize_account_settings_update_instruction(rest)?,
+            20 => Self::unpack_init_dapp_book_update_instruction(rest)?,
+            21 => Self::unpack_finalize_dapp_book_update_instruction(rest)?,
             _ => return Err(ProgramError::InvalidInstructionData),
         })
     }
@@ -662,8 +698,13 @@ impl ProgramInstruction {
         let account_guid_hash = unpack_account_guid_hash(
             utils::read_slice(iter, 32).ok_or(ProgramError::InvalidInstructionData)?,
         )?;
+        let dapp = AddressBookEntry::unpack_from_slice(
+            utils::read_slice(iter, AddressBookEntry::LEN)
+                .ok_or(ProgramError::InvalidInstructionData)?,
+        )?;
         Ok(Self::InitDAppTransaction {
             account_guid_hash,
+            dapp,
             instructions: read_instructions(iter)?,
         })
     }
@@ -675,8 +716,13 @@ impl ProgramInstruction {
         let account_guid_hash = unpack_account_guid_hash(
             utils::read_slice(iter, 32).ok_or(ProgramError::InvalidInstructionData)?,
         )?;
+        let dapp = AddressBookEntry::unpack_from_slice(
+            utils::read_slice(iter, AddressBookEntry::LEN)
+                .ok_or(ProgramError::InvalidInstructionData)?,
+        )?;
         Ok(Self::FinalizeDAppTransaction {
             account_guid_hash,
+            dapp,
             instructions: read_instructions(iter)?,
         })
     }
@@ -704,6 +750,22 @@ impl ProgramInstruction {
             )?,
             whitelist_enabled: utils::unpack_option::<BooleanSetting>(iter)?,
             dapps_enabled: utils::unpack_option::<BooleanSetting>(iter)?,
+        })
+    }
+
+    fn unpack_init_dapp_book_update_instruction(
+        bytes: &[u8],
+    ) -> Result<ProgramInstruction, ProgramError> {
+        Ok(Self::InitDAppBookUpdate {
+            update: DAppBookUpdate::unpack(bytes)?,
+        })
+    }
+
+    fn unpack_finalize_dapp_book_update_instruction(
+        bytes: &[u8],
+    ) -> Result<ProgramInstruction, ProgramError> {
+        Ok(Self::FinalizeDAppBookUpdate {
+            update: DAppBookUpdate::unpack(bytes)?,
         })
     }
 }
@@ -842,6 +904,33 @@ impl BalanceAccountUpdate {
         append_signers(&self.remove_transfer_approvers, dst);
         append_address_book_entries(&self.add_allowed_destinations, dst);
         append_address_book_entries(&self.remove_allowed_destinations, dst);
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct DAppBookUpdate {
+    pub add_dapps: Vec<(SlotId<AddressBookEntry>, AddressBookEntry)>,
+    pub remove_dapps: Vec<(SlotId<AddressBookEntry>, AddressBookEntry)>,
+}
+
+impl DAppBookUpdate {
+    fn unpack(bytes: &[u8]) -> Result<DAppBookUpdate, ProgramError> {
+        if bytes.len() < 1 {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+        let mut iter = bytes.iter();
+        let add_dapps = read_address_book_entries(&mut iter)?;
+        let remove_dapps = read_address_book_entries(&mut iter)?;
+
+        Ok(DAppBookUpdate {
+            add_dapps,
+            remove_dapps,
+        })
+    }
+
+    pub fn pack(&self, dst: &mut Vec<u8>) {
+        append_address_book_entries(&self.add_dapps, dst);
+        append_address_book_entries(&self.remove_dapps, dst);
     }
 }
 

--- a/src/model/address_book.rs
+++ b/src/model/address_book.rs
@@ -6,7 +6,7 @@ use solana_program::program_pack::{Pack, Sealed};
 use solana_program::pubkey::Pubkey;
 
 pub type AddressBook = Slots<AddressBookEntry, { Wallet::MAX_ADDRESS_BOOK_ENTRIES }>;
-pub type DAppBook = Slots<AddressBookEntry, { Wallet::MAX_DAPP_BOOK_ENTRIES }>;
+pub type DAppBook = Slots<DAppBookEntry, { Wallet::MAX_DAPP_BOOK_ENTRIES }>;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Copy)]
 pub struct AddressBookEntryNameHash([u8; 32]);
@@ -54,3 +54,6 @@ impl Pack for AddressBookEntry {
         })
     }
 }
+
+pub type DAppBookEntry = AddressBookEntry;
+pub type DAppBookEntryNameHash = AddressBookEntryNameHash;

--- a/src/model/multisig_op.rs
+++ b/src/model/multisig_op.rs
@@ -3,7 +3,7 @@ use crate::instruction::{
     append_instruction, BalanceAccountUpdate, DAppBookUpdate, WalletConfigPolicyUpdate,
     WalletUpdate,
 };
-use crate::model::address_book::AddressBookEntry;
+use crate::model::address_book::DAppBookEntry;
 use crate::model::balance_account::BalanceAccountGuidHash;
 use crate::model::signer::Signer;
 use crate::model::wallet::Wallet;
@@ -478,7 +478,7 @@ pub enum MultisigOpParams {
     DAppTransaction {
         wallet_address: Pubkey,
         account_guid_hash: BalanceAccountGuidHash,
-        dapp: AddressBookEntry,
+        dapp: DAppBookEntry,
         instructions: Vec<Instruction>,
     },
     UpdateAccountSettings {
@@ -626,7 +626,7 @@ impl MultisigOpParams {
                 bytes.extend_from_slice(&wallet_address.to_bytes());
                 bytes.extend_from_slice(&account_guid_hash.to_bytes());
                 bytes.put_u16_le(instructions.len().as_u16());
-                let mut buf = vec![0; AddressBookEntry::LEN];
+                let mut buf = vec![0; DAppBookEntry::LEN];
                 dapp.pack_into_slice(buf.as_mut_slice());
                 bytes.extend_from_slice(&buf[..]);
                 for instruction in instructions.into_iter() {

--- a/src/model/multisig_op.rs
+++ b/src/model/multisig_op.rs
@@ -1,7 +1,9 @@
 use crate::error::WalletError;
 use crate::instruction::{
-    append_instruction, BalanceAccountUpdate, WalletConfigPolicyUpdate, WalletUpdate,
+    append_instruction, BalanceAccountUpdate, DAppBookUpdate, WalletConfigPolicyUpdate,
+    WalletUpdate,
 };
+use crate::model::address_book::AddressBookEntry;
 use crate::model::balance_account::BalanceAccountGuidHash;
 use crate::model::signer::Signer;
 use crate::model::wallet::Wallet;
@@ -476,13 +478,18 @@ pub enum MultisigOpParams {
     DAppTransaction {
         wallet_address: Pubkey,
         account_guid_hash: BalanceAccountGuidHash,
+        dapp: AddressBookEntry,
         instructions: Vec<Instruction>,
     },
-    AccountSettingsUpdate {
+    UpdateAccountSettings {
         wallet_address: Pubkey,
         account_guid_hash: BalanceAccountGuidHash,
         whitelist_enabled: Option<BooleanSetting>,
         dapps_enabled: Option<BooleanSetting>,
+    },
+    UpdateDAppBook {
+        wallet_address: Pubkey,
+        update: DAppBookUpdate,
     },
 }
 
@@ -611,6 +618,7 @@ impl MultisigOpParams {
             MultisigOpParams::DAppTransaction {
                 wallet_address,
                 account_guid_hash,
+                dapp,
                 instructions,
             } => {
                 let mut bytes: Vec<u8> = Vec::new();
@@ -618,6 +626,9 @@ impl MultisigOpParams {
                 bytes.extend_from_slice(&wallet_address.to_bytes());
                 bytes.extend_from_slice(&account_guid_hash.to_bytes());
                 bytes.put_u16_le(instructions.len().as_u16());
+                let mut buf = vec![0; AddressBookEntry::LEN];
+                dapp.pack_into_slice(buf.as_mut_slice());
+                bytes.extend_from_slice(&buf[..]);
                 for instruction in instructions.into_iter() {
                     append_instruction(instruction, &mut bytes);
                 }
@@ -639,7 +650,7 @@ impl MultisigOpParams {
                     .copy_from_slice(&update_bytes);
                 hash(&bytes)
             }
-            MultisigOpParams::AccountSettingsUpdate {
+            MultisigOpParams::UpdateAccountSettings {
                 wallet_address,
                 account_guid_hash,
                 whitelist_enabled,
@@ -651,6 +662,21 @@ impl MultisigOpParams {
                 bytes.extend_from_slice(account_guid_hash.to_bytes());
                 pack_option(whitelist_enabled.as_ref(), &mut bytes);
                 pack_option(dapps_enabled.as_ref(), &mut bytes);
+                hash(&bytes)
+            }
+            MultisigOpParams::UpdateDAppBook {
+                wallet_address,
+                update,
+            } => {
+                let mut update_bytes: Vec<u8> = Vec::new();
+                update.pack(&mut update_bytes);
+
+                let mut bytes: Vec<u8> = Vec::new();
+                bytes.resize(1 + PUBKEY_BYTES + update_bytes.len(), 0);
+                bytes[0] = 9; // type code
+                bytes[1..1 + PUBKEY_BYTES].copy_from_slice(&wallet_address.to_bytes());
+                bytes[1 + PUBKEY_BYTES..1 + PUBKEY_BYTES + update_bytes.len()]
+                    .copy_from_slice(&update_bytes);
                 hash(&bytes)
             }
         }

--- a/src/model/wallet.rs
+++ b/src/model/wallet.rs
@@ -294,7 +294,7 @@ impl Wallet {
         Ok(())
     }
 
-    pub fn dapp_allowed(&mut self, dapp: DAppBookEntry) -> bool {
+    pub fn dapp_allowed(&self, dapp: DAppBookEntry) -> bool {
         self.dapp_book.find_id(&dapp).is_some()
     }
 

--- a/src/model/wallet.rs
+++ b/src/model/wallet.rs
@@ -1,5 +1,7 @@
 use crate::error::WalletError;
-use crate::instruction::{BalanceAccountUpdate, WalletConfigPolicyUpdate, WalletUpdate};
+use crate::instruction::{
+    BalanceAccountUpdate, DAppBookUpdate, WalletConfigPolicyUpdate, WalletUpdate,
+};
 use crate::model::address_book::{
     AddressBook, AddressBookEntry, AddressBookEntryNameHash, DAppBook,
 };
@@ -276,6 +278,18 @@ impl Wallet {
             );
             return Err(WalletError::InvalidApproverCount.into());
         }
+
+        Ok(())
+    }
+
+    pub fn validate_dapp_book_update(&self, update: &DAppBookUpdate) -> ProgramResult {
+        let mut self_clone = self.clone();
+        self_clone.update_dapp_book(update)
+    }
+
+    pub fn update_dapp_book(&mut self, update: &DAppBookUpdate) -> ProgramResult {
+        self.add_dapp_book_entries(&update.add_dapps)?;
+        self.remove_dapp_book_entries(&update.remove_dapps)?;
 
         Ok(())
     }

--- a/src/model/wallet.rs
+++ b/src/model/wallet.rs
@@ -3,7 +3,7 @@ use crate::instruction::{
     BalanceAccountUpdate, DAppBookUpdate, WalletConfigPolicyUpdate, WalletUpdate,
 };
 use crate::model::address_book::{
-    AddressBook, AddressBookEntry, AddressBookEntryNameHash, DAppBook,
+    AddressBook, AddressBookEntry, AddressBookEntryNameHash, DAppBook, DAppBookEntry,
 };
 use crate::model::balance_account::{
     AllowedDestinations, BalanceAccount, BalanceAccountGuidHash, BalanceAccountNameHash,
@@ -294,6 +294,10 @@ impl Wallet {
         Ok(())
     }
 
+    pub fn dapp_allowed(&mut self, dapp: DAppBookEntry) -> bool {
+        self.dapp_book.find_id(&dapp).is_some()
+    }
+
     pub fn validate_add_balance_account(
         &self,
         account_guid_hash: &BalanceAccountGuidHash,
@@ -491,7 +495,7 @@ impl Wallet {
 
     fn add_dapp_book_entries(
         &mut self,
-        entries_to_add: &Vec<(SlotId<AddressBookEntry>, AddressBookEntry)>,
+        entries_to_add: &Vec<(SlotId<DAppBookEntry>, DAppBookEntry)>,
     ) -> ProgramResult {
         if !self.dapp_book.can_be_inserted(entries_to_add) {
             msg!("Failed to add dapp book entries: at least one of the provided slots is already taken");
@@ -503,7 +507,7 @@ impl Wallet {
 
     fn remove_dapp_book_entries(
         &mut self,
-        entries_to_remove: &Vec<(SlotId<AddressBookEntry>, AddressBookEntry)>,
+        entries_to_remove: &Vec<(SlotId<DAppBookEntry>, DAppBookEntry)>,
     ) -> ProgramResult {
         if !self.dapp_book.can_be_removed(entries_to_remove) {
             msg!("Failed to remove dapp book entries: at least one of the provided entries is not present in the config");

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -16,12 +16,12 @@ use spl_token::instruction as spl_instruction;
 use spl_token::state::{Account as SPLAccount, Account};
 
 use crate::error::WalletError;
-use crate::handlers::dapp_transaction_handler;
 use crate::handlers::utils::{
     finalize_multisig_op, get_clock_from_next_account, next_program_account_info,
     start_multisig_config_op, start_multisig_transfer_op, validate_balance_account_and_get_seed,
 };
 use crate::handlers::{account_settings_update_handler, wallet_config_policy_update_handler};
+use crate::handlers::{dapp_book_update_handler, dapp_transaction_handler};
 use crate::instruction::{BalanceAccountUpdate, ProgramInstruction, WalletUpdate};
 use crate::model::address_book::AddressBookEntryNameHash;
 use crate::model::balance_account::BalanceAccountGuidHash;
@@ -182,21 +182,25 @@ impl Processor {
 
             ProgramInstruction::InitDAppTransaction {
                 ref account_guid_hash,
+                dapp,
                 instructions,
             } => dapp_transaction_handler::init(
                 program_id,
                 accounts,
                 account_guid_hash,
+                dapp,
                 instructions,
             ),
 
             ProgramInstruction::FinalizeDAppTransaction {
                 ref account_guid_hash,
+                dapp,
                 ref instructions,
             } => dapp_transaction_handler::finalize(
                 program_id,
                 accounts,
                 account_guid_hash,
+                dapp,
                 instructions,
             ),
 
@@ -223,6 +227,14 @@ impl Processor {
                 whitelist_enabled,
                 dapps_enabled,
             ),
+
+            ProgramInstruction::InitDAppBookUpdate { update } => {
+                dapp_book_update_handler::init(program_id, &accounts, &update)
+            }
+
+            ProgramInstruction::FinalizeDAppBookUpdate { update } => {
+                dapp_book_update_handler::finalize(program_id, &accounts, &update)
+            }
         }
     }
 

--- a/tests/common/instructions.rs
+++ b/tests/common/instructions.rs
@@ -9,7 +9,9 @@ use strike_wallet::instruction::{
     BalanceAccountUpdate, DAppBookUpdate, ProgramInstruction, WalletConfigPolicyUpdate,
     WalletUpdate,
 };
-use strike_wallet::model::address_book::{AddressBookEntry, AddressBookEntryNameHash};
+use strike_wallet::model::address_book::{
+    AddressBookEntry, AddressBookEntryNameHash, DAppBookEntry,
+};
 use strike_wallet::model::balance_account::{BalanceAccountGuidHash, BalanceAccountNameHash};
 use strike_wallet::model::multisig_op::{
     ApprovalDisposition, BooleanSetting, SlotUpdateType, WrapDirection,
@@ -612,7 +614,7 @@ pub fn init_dapp_transaction(
     multisig_op_account: &Pubkey,
     assistant_account: &Pubkey,
     account_guid_hash: &BalanceAccountGuidHash,
-    dapp: AddressBookEntry,
+    dapp: DAppBookEntry,
     instructions: Vec<Instruction>,
 ) -> Instruction {
     let data = ProgramInstruction::InitDAppTransaction {
@@ -644,7 +646,7 @@ pub fn finalize_dapp_transaction(
     balance_account: &Pubkey,
     rent_collector_account: &Pubkey,
     account_guid_hash: &BalanceAccountGuidHash,
-    dapp: AddressBookEntry,
+    dapp: DAppBookEntry,
     instructions: &Vec<Instruction>,
 ) -> Instruction {
     let data = ProgramInstruction::FinalizeDAppTransaction {

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -19,7 +19,9 @@ use std::borrow::BorrowMut;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use strike_wallet::instruction::{BalanceAccountUpdate, WalletConfigPolicyUpdate, WalletUpdate};
+use strike_wallet::instruction::{
+    BalanceAccountUpdate, DAppBookUpdate, WalletConfigPolicyUpdate, WalletUpdate,
+};
 use strike_wallet::model::address_book::{
     AddressBook, AddressBookEntry, AddressBookEntryNameHash, DAppBook,
 };
@@ -715,7 +717,7 @@ pub async fn account_settings_update(
 
     assert_eq!(
         multisig_op.params_hash,
-        MultisigOpParams::AccountSettingsUpdate {
+        MultisigOpParams::UpdateAccountSettings {
             wallet_address: context.wallet_account.pubkey(),
             account_guid_hash: context.balance_account_guid_hash,
             whitelist_enabled: whitelist_status,
@@ -801,6 +803,48 @@ pub async fn account_settings_update(
         starting_rent_collector_balance + op_account_balance - 5000,
         ending_rent_collector_balance
     );
+}
+
+pub async fn init_dapp_book_update(
+    test_context: &mut TestContext,
+    wallet_account: Pubkey,
+    assistant: &Keypair,
+    update: DAppBookUpdate,
+) -> Result<Pubkey, TransportError> {
+    let multisig_op_keypair = Keypair::new();
+    let multisig_op_pubkey = multisig_op_keypair.pubkey();
+
+    let instruction = instructions::init_dapp_book_update(
+        &test_context.program_id,
+        &wallet_account,
+        &multisig_op_pubkey,
+        &assistant.pubkey(),
+        update,
+    );
+
+    init_multisig_op(test_context, multisig_op_keypair, instruction, assistant)
+        .await
+        .map(|_| multisig_op_pubkey)
+}
+
+pub async fn finalize_dapp_book_update(
+    test_context: &mut TestContext,
+    wallet_account: Pubkey,
+    multisig_op_account: Pubkey,
+    update: DAppBookUpdate,
+) {
+    finalize_multisig_op(
+        test_context,
+        multisig_op_account,
+        instructions::finalize_dapp_book_update(
+            &test_context.program_id,
+            &wallet_account,
+            &multisig_op_account,
+            &test_context.payer.pubkey(),
+            update,
+        ),
+    )
+    .await;
 }
 
 pub async fn verify_whitelist_status(
@@ -993,6 +1037,7 @@ pub struct BalanceAccountTestContext {
     pub payer: Keypair,
     pub program_id: Pubkey,
     pub banks_client: BanksClient,
+    pub rent: Rent,
     pub wallet_account: Keypair,
     pub multisig_op_account: Keypair,
     pub assistant_account: Keypair,
@@ -1005,6 +1050,20 @@ pub struct BalanceAccountTestContext {
     pub allowed_destination: AddressBookEntry,
     pub destination: Keypair,
     pub params_hash: Hash,
+    pub allowed_dapp: AddressBookEntry,
+}
+
+impl BalanceAccountTestContext {
+    fn to_test_context(&self) -> TestContext {
+        let new_payer = Keypair::from_bytes(&self.payer.to_bytes()[..]).unwrap();
+        TestContext {
+            program_id: self.program_id,
+            banks_client: self.banks_client.clone(),
+            rent: self.rent,
+            payer: new_payer,
+            recent_blockhash: self.recent_blockhash,
+        }
+    }
 }
 
 pub async fn setup_balance_account_tests(
@@ -1029,6 +1088,10 @@ pub async fn setup_balance_account_tests(
     let addr_book_entry2 = AddressBookEntry {
         address: Keypair::new().pubkey(),
         name_hash: AddressBookEntryNameHash::new(&hash_of(b"Destination 2 Name")),
+    };
+    let allowed_dapp = AddressBookEntry {
+        address: Keypair::new().pubkey(),
+        name_hash: AddressBookEntryNameHash::new(&hash_of(b"DApp Name")),
     };
 
     // first initialize the wallet
@@ -1155,6 +1218,7 @@ pub async fn setup_balance_account_tests(
         payer,
         program_id,
         banks_client,
+        rent,
         wallet_account,
         multisig_op_account,
         assistant_account,
@@ -1167,6 +1231,7 @@ pub async fn setup_balance_account_tests(
         allowed_destination: addr_book_entry,
         destination,
         params_hash: multisig_op.params_hash,
+        allowed_dapp,
     }
 }
 
@@ -1319,6 +1384,37 @@ pub async fn setup_balance_account_tests_and_finalize(
         &[&context.balance_account_guid_hash.to_bytes()],
         &context.program_id,
     );
+
+    // add allowed dapp
+    let mut test_context = context.to_test_context();
+    let update = DAppBookUpdate {
+        add_dapps: vec![(SlotId::new(0), context.allowed_dapp)],
+        remove_dapps: vec![],
+    };
+
+    let multisig_op_account = init_dapp_book_update(
+        &mut test_context,
+        context.wallet_account.pubkey(),
+        &context.assistant_account,
+        update.clone(),
+    )
+    .await
+    .unwrap();
+
+    approve_n_of_n_multisig_op(
+        &mut test_context,
+        &multisig_op_account,
+        vec![&context.approvers[0], &context.approvers[1]],
+    )
+    .await;
+
+    finalize_dapp_book_update(
+        &mut test_context,
+        context.wallet_account.pubkey(),
+        multisig_op_account,
+        update.clone(),
+    )
+    .await;
 
     (context, source_account)
 }

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -23,7 +23,8 @@ use strike_wallet::instruction::{
     BalanceAccountUpdate, DAppBookUpdate, WalletConfigPolicyUpdate, WalletUpdate,
 };
 use strike_wallet::model::address_book::{
-    AddressBook, AddressBookEntry, AddressBookEntryNameHash, DAppBook,
+    AddressBook, AddressBookEntry, AddressBookEntryNameHash, DAppBook, DAppBookEntry,
+    DAppBookEntryNameHash,
 };
 use strike_wallet::model::balance_account::{BalanceAccountGuidHash, BalanceAccountNameHash};
 use strike_wallet::model::multisig_op::{
@@ -1050,7 +1051,7 @@ pub struct BalanceAccountTestContext {
     pub allowed_destination: AddressBookEntry,
     pub destination: Keypair,
     pub params_hash: Hash,
-    pub allowed_dapp: AddressBookEntry,
+    pub allowed_dapp: DAppBookEntry,
 }
 
 impl BalanceAccountTestContext {
@@ -1089,9 +1090,9 @@ pub async fn setup_balance_account_tests(
         address: Keypair::new().pubkey(),
         name_hash: AddressBookEntryNameHash::new(&hash_of(b"Destination 2 Name")),
     };
-    let allowed_dapp = AddressBookEntry {
+    let allowed_dapp = DAppBookEntry {
         address: Keypair::new().pubkey(),
-        name_hash: AddressBookEntryNameHash::new(&hash_of(b"DApp Name")),
+        name_hash: DAppBookEntryNameHash::new(&hash_of(b"DApp Name")),
     };
 
     // first initialize the wallet

--- a/tests/dapp_book_update_tests.rs
+++ b/tests/dapp_book_update_tests.rs
@@ -9,7 +9,7 @@ use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer as SdkSigner;
 use std::time::{Duration, SystemTime};
 use strike_wallet::instruction::DAppBookUpdate;
-use strike_wallet::model::address_book::{AddressBookEntry, AddressBookEntryNameHash};
+use strike_wallet::model::address_book::{DAppBookEntry, DAppBookEntryNameHash};
 use strike_wallet::model::multisig_op::{
     ApprovalDisposition, ApprovalDispositionRecord, MultisigOpParams, OperationDisposition,
 };
@@ -46,9 +46,9 @@ async fn test_dapp_book_update() {
     let dapp_program_id = Keypair::new().pubkey();
     let dapp_slot = (
         SlotId::new(0),
-        AddressBookEntry {
+        DAppBookEntry {
             address: dapp_program_id,
-            name_hash: AddressBookEntryNameHash::new(&hash_of(b"DApp Name")),
+            name_hash: DAppBookEntryNameHash::new(&hash_of(b"DApp Name")),
         },
     );
 

--- a/tests/dapp_book_update_tests.rs
+++ b/tests/dapp_book_update_tests.rs
@@ -1,0 +1,158 @@
+#![cfg(feature = "test-bpf")]
+mod common;
+pub use common::instructions::*;
+pub use common::utils::*;
+
+pub use common::utils;
+use solana_program_test::tokio;
+use solana_sdk::signature::Keypair;
+use solana_sdk::signer::Signer as SdkSigner;
+use std::time::{Duration, SystemTime};
+use strike_wallet::instruction::DAppBookUpdate;
+use strike_wallet::model::address_book::{AddressBookEntry, AddressBookEntryNameHash};
+use strike_wallet::model::multisig_op::{
+    ApprovalDisposition, ApprovalDispositionRecord, MultisigOpParams, OperationDisposition,
+};
+use strike_wallet::utils::{SlotId, Slots};
+
+#[tokio::test]
+async fn test_dapp_book_update() {
+    let started_at = SystemTime::now();
+    let mut context = setup_test(30_000).await;
+
+    let wallet_account = Keypair::new();
+    let assistant_account = Keypair::new();
+
+    let approvers = vec![Keypair::new()];
+    let signers = vec![approvers[0].pubkey_as_signer()];
+
+    utils::init_wallet(
+        &mut context.banks_client,
+        &context.payer,
+        context.recent_blockhash,
+        &context.program_id,
+        &wallet_account,
+        &assistant_account,
+        Some(1),
+        Some(vec![(SlotId::new(0), signers[0])]),
+        Some(vec![(SlotId::new(0), signers[0])]),
+        Some(Duration::from_secs(3600)),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // add a dapp to dapp book
+    let dapp_program_id = Keypair::new().pubkey();
+    let dapp_slot = (
+        SlotId::new(0),
+        AddressBookEntry {
+            address: dapp_program_id,
+            name_hash: AddressBookEntryNameHash::new(&hash_of(b"DApp Name")),
+        },
+    );
+
+    let add_dapp = DAppBookUpdate {
+        add_dapps: vec![dapp_slot],
+        remove_dapps: vec![],
+    };
+
+    let multisig_op_account = utils::init_dapp_book_update(
+        &mut context,
+        wallet_account.pubkey(),
+        &assistant_account,
+        add_dapp.clone(),
+    )
+    .await
+    .unwrap();
+
+    assert_initialized_multisig_op(
+        &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,
+        started_at,
+        Duration::from_secs(3600),
+        1,
+        &vec![ApprovalDispositionRecord {
+            approver: approvers[0].pubkey(),
+            disposition: ApprovalDisposition::NONE,
+        }],
+        OperationDisposition::NONE,
+        &MultisigOpParams::UpdateDAppBook {
+            wallet_address: wallet_account.pubkey(),
+            update: add_dapp.clone(),
+        },
+    );
+
+    let wallet = get_wallet(&mut context.banks_client, &wallet_account.pubkey()).await;
+    // ensure that config policy updates are not locked
+    assert!(!wallet.config_policy_update_locked);
+
+    approve_n_of_n_multisig_op(&mut context, &multisig_op_account, vec![&approvers[0]]).await;
+
+    utils::finalize_dapp_book_update(
+        &mut context,
+        wallet_account.pubkey(),
+        multisig_op_account,
+        add_dapp.clone(),
+    )
+    .await;
+
+    assert_eq!(
+        Slots::from_vec(vec![dapp_slot]),
+        get_wallet(&mut context.banks_client, &wallet_account.pubkey())
+            .await
+            .dapp_book
+    );
+
+    // now remove it
+    let remove_dapp = DAppBookUpdate {
+        add_dapps: vec![],
+        remove_dapps: vec![dapp_slot],
+    };
+
+    let remove_multisig_op_account = utils::init_dapp_book_update(
+        &mut context,
+        wallet_account.pubkey(),
+        &assistant_account,
+        remove_dapp.clone(),
+    )
+    .await
+    .unwrap();
+
+    assert_initialized_multisig_op(
+        &get_multisig_op_data(&mut context.banks_client, remove_multisig_op_account).await,
+        started_at,
+        Duration::from_secs(3600),
+        1,
+        &vec![ApprovalDispositionRecord {
+            approver: approvers[0].pubkey(),
+            disposition: ApprovalDisposition::NONE,
+        }],
+        OperationDisposition::NONE,
+        &MultisigOpParams::UpdateDAppBook {
+            wallet_address: wallet_account.pubkey(),
+            update: remove_dapp.clone(),
+        },
+    );
+
+    approve_n_of_n_multisig_op(
+        &mut context,
+        &remove_multisig_op_account,
+        vec![&approvers[0]],
+    )
+    .await;
+
+    utils::finalize_dapp_book_update(
+        &mut context,
+        wallet_account.pubkey(),
+        remove_multisig_op_account,
+        remove_dapp.clone(),
+    )
+    .await;
+
+    assert_eq!(
+        Slots::new(),
+        get_wallet(&mut context.banks_client, &wallet_account.pubkey())
+            .await
+            .dapp_book
+    );
+}

--- a/tests/dapp_transaction_tests.rs
+++ b/tests/dapp_transaction_tests.rs
@@ -1,15 +1,7 @@
 #![cfg(feature = "test-bpf")]
-mod common;
-pub use common::instructions::*;
-pub use common::utils::*;
 
 use std::borrow::BorrowMut;
 
-use crate::common::utils;
-use crate::utils::BalanceAccountTestContext;
-use common::instructions::{
-    finalize_dapp_transaction, init_dapp_transaction, init_transfer, set_approval_disposition,
-};
 use solana_program::instruction::Instruction;
 use solana_program::instruction::InstructionError::Custom;
 use solana_program::program_pack::Pack;
@@ -20,14 +12,27 @@ use solana_sdk::account::ReadableAccount;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer as SdkSigner;
 use solana_sdk::transaction::{Transaction, TransactionError};
+
+pub use common::instructions::*;
+use common::instructions::{
+    finalize_dapp_transaction, init_dapp_transaction, init_transfer, set_approval_disposition,
+};
+pub use common::utils::*;
 use strike_wallet::error::WalletError;
+use strike_wallet::model::address_book::{AddressBookEntry, AddressBookEntryNameHash};
 use strike_wallet::model::balance_account::BalanceAccountGuidHash;
 use strike_wallet::model::multisig_op::{ApprovalDisposition, BooleanSetting, MultisigOp};
+
+use crate::common::utils;
+use crate::utils::BalanceAccountTestContext;
+
+mod common;
 
 struct DAppTest {
     context: BalanceAccountTestContext,
     balance_account: Pubkey,
     multisig_op_account: Keypair,
+    dapp: AddressBookEntry,
     inner_instructions: Vec<Instruction>,
     inner_multisig_op_account: Keypair,
 }
@@ -40,9 +45,19 @@ async fn setup_dapp_test() -> DAppTest {
     let multisig_account_rent = rent.minimum_balance(MultisigOp::LEN);
     let multisig_op_account = Keypair::new();
 
-    account_settings_update(&mut context, None, Some(BooleanSetting::On), None).await;
+    account_settings_update(
+        &mut context,
+        Some(BooleanSetting::Off),
+        Some(BooleanSetting::On),
+        None,
+    )
+    .await;
 
     let inner_multisig_op_account = Keypair::new();
+    let dapp = AddressBookEntry {
+        address: context.program_id.clone(),
+        name_hash: AddressBookEntryNameHash::new(&hash_of(b"Strike Wallet")),
+    };
 
     let inner_instructions = vec![
         system_instruction::create_account(
@@ -84,6 +99,7 @@ async fn setup_dapp_test() -> DAppTest {
                     &multisig_op_account.pubkey(),
                     &context.assistant_account.pubkey(),
                     &context.balance_account_guid_hash,
+                    dapp,
                     inner_instructions.clone(),
                 ),
             ],
@@ -102,6 +118,7 @@ async fn setup_dapp_test() -> DAppTest {
         context,
         balance_account,
         multisig_op_account,
+        dapp,
         inner_instructions,
         inner_multisig_op_account,
     }
@@ -125,6 +142,7 @@ async fn test_dapp_transaction_simulation() {
                     &dapp_test.balance_account,
                     &context.payer.pubkey(),
                     &context.balance_account_guid_hash,
+                    dapp_test.dapp,
                     &dapp_test.inner_instructions,
                 )],
                 Some(&context.payer.pubkey()),
@@ -160,6 +178,7 @@ async fn test_dapp_transaction_bad_signature() {
                     &dapp_test.balance_account,
                     &context.payer.pubkey(),
                     &BalanceAccountGuidHash::zero(),
+                    dapp_test.dapp,
                     &dapp_test.inner_instructions,
                 )],
                 Some(&context.payer.pubkey()),
@@ -217,6 +236,7 @@ async fn test_dapp_transaction() {
                 &dapp_test.balance_account,
                 &context.payer.pubkey(),
                 &context.balance_account_guid_hash,
+                dapp_test.dapp,
                 &dapp_test.inner_instructions,
             )],
             Some(&context.payer.pubkey()),
@@ -283,6 +303,7 @@ async fn test_dapp_transaction_denied() {
                 &dapp_test.balance_account,
                 &context.payer.pubkey(),
                 &context.balance_account_guid_hash,
+                dapp_test.dapp,
                 &dapp_test.inner_instructions,
             )],
             Some(&context.payer.pubkey()),
@@ -370,6 +391,11 @@ async fn test_dapp_transaction_with_spl_transfers() {
         .unwrap(),
     ];
 
+    let dapp = AddressBookEntry {
+        address: context.program_id.clone(),
+        name_hash: AddressBookEntryNameHash::new(&hash_of(b"Strike Wallet")),
+    };
+
     context
         .banks_client
         .process_transaction(Transaction::new_signed_with_payer(
@@ -387,6 +413,7 @@ async fn test_dapp_transaction_with_spl_transfers() {
                     &multisig_op_account.pubkey(),
                     &context.assistant_account.pubkey(),
                     &context.balance_account_guid_hash,
+                    dapp,
                     inner_instructions.clone(),
                 ),
             ],
@@ -413,6 +440,7 @@ async fn test_dapp_transaction_with_spl_transfers() {
                     &balance_account,
                     &context.payer.pubkey(),
                     &context.balance_account_guid_hash,
+                    dapp,
                     &inner_instructions,
                 )],
                 Some(&context.payer.pubkey()),
@@ -427,14 +455,17 @@ async fn test_dapp_transaction_with_spl_transfers() {
 }
 
 #[tokio::test]
-async fn test_dapp_transfer_without_dapps_enabled() {
+async fn test_dapp_transaction_without_dapps_enabled() {
     let (mut context, _balance_account) =
         utils::setup_balance_account_tests_and_finalize(None).await;
 
     let rent = context.banks_client.get_rent().await.unwrap();
     let multisig_account_rent = rent.minimum_balance(MultisigOp::LEN);
     let multisig_op_account = Keypair::new();
-
+    let dapp = AddressBookEntry {
+        address: context.program_id.clone(),
+        name_hash: AddressBookEntryNameHash::new(&hash_of(b"Strike Wallet")),
+    };
     assert_eq!(
         context
             .banks_client
@@ -453,6 +484,7 @@ async fn test_dapp_transfer_without_dapps_enabled() {
                         &multisig_op_account.pubkey(),
                         &context.assistant_account.pubkey(),
                         &context.balance_account_guid_hash,
+                        dapp,
                         vec![],
                     ),
                 ],
@@ -469,4 +501,109 @@ async fn test_dapp_transfer_without_dapps_enabled() {
             .unwrap(),
         TransactionError::InstructionError(1, Custom(WalletError::DAppsDisabled as u32)),
     );
+}
+
+#[tokio::test]
+async fn test_dapp_transaction_unwhitelisted() {
+    let (mut context, _balance_account) =
+        utils::setup_balance_account_tests_and_finalize(None).await;
+
+    account_settings_update(
+        &mut context,
+        Some(BooleanSetting::On),
+        Some(BooleanSetting::On),
+        None,
+    )
+    .await;
+
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let multisig_account_rent = rent.minimum_balance(MultisigOp::LEN);
+    let multisig_op_account = Keypair::new();
+    let dapp = AddressBookEntry {
+        address: context.program_id.clone(),
+        name_hash: AddressBookEntryNameHash::new(&hash_of(b"Strike Wallet")),
+    };
+    assert_eq!(
+        context
+            .banks_client
+            .process_transaction(Transaction::new_signed_with_payer(
+                &[
+                    system_instruction::create_account(
+                        &context.payer.pubkey(),
+                        &multisig_op_account.pubkey(),
+                        multisig_account_rent,
+                        MultisigOp::LEN as u64,
+                        &context.program_id,
+                    ),
+                    init_dapp_transaction(
+                        &context.program_id,
+                        &context.wallet_account.pubkey(),
+                        &multisig_op_account.pubkey(),
+                        &context.assistant_account.pubkey(),
+                        &context.balance_account_guid_hash,
+                        dapp,
+                        vec![],
+                    ),
+                ],
+                Some(&context.payer.pubkey()),
+                &[
+                    &context.payer,
+                    &multisig_op_account,
+                    &context.assistant_account,
+                ],
+                context.recent_blockhash,
+            ))
+            .await
+            .unwrap_err()
+            .unwrap(),
+        TransactionError::InstructionError(1, Custom(WalletError::DAppNotAllowed as u32)),
+    );
+}
+
+#[tokio::test]
+async fn test_dapp_transaction_whitelisted() {
+    let (mut context, _balance_account) =
+        utils::setup_balance_account_tests_and_finalize(None).await;
+
+    account_settings_update(
+        &mut context,
+        Some(BooleanSetting::On),
+        Some(BooleanSetting::On),
+        None,
+    )
+    .await;
+
+    let multisig_account_rent = context.rent.minimum_balance(MultisigOp::LEN);
+    let multisig_op_account = Keypair::new();
+    context
+        .banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[
+                system_instruction::create_account(
+                    &context.payer.pubkey(),
+                    &multisig_op_account.pubkey(),
+                    multisig_account_rent,
+                    MultisigOp::LEN as u64,
+                    &context.program_id,
+                ),
+                init_dapp_transaction(
+                    &context.program_id,
+                    &context.wallet_account.pubkey(),
+                    &multisig_op_account.pubkey(),
+                    &context.assistant_account.pubkey(),
+                    &context.balance_account_guid_hash,
+                    context.allowed_dapp,
+                    vec![],
+                ),
+            ],
+            Some(&context.payer.pubkey()),
+            &[
+                &context.payer,
+                &multisig_op_account,
+                &context.assistant_account,
+            ],
+            context.recent_blockhash,
+        ))
+        .await
+        .unwrap();
 }

--- a/tests/dapp_transaction_tests.rs
+++ b/tests/dapp_transaction_tests.rs
@@ -19,7 +19,7 @@ use common::instructions::{
 };
 pub use common::utils::*;
 use strike_wallet::error::WalletError;
-use strike_wallet::model::address_book::{AddressBookEntry, AddressBookEntryNameHash};
+use strike_wallet::model::address_book::{DAppBookEntry, DAppBookEntryNameHash};
 use strike_wallet::model::balance_account::BalanceAccountGuidHash;
 use strike_wallet::model::multisig_op::{ApprovalDisposition, BooleanSetting, MultisigOp};
 
@@ -32,7 +32,7 @@ struct DAppTest {
     context: BalanceAccountTestContext,
     balance_account: Pubkey,
     multisig_op_account: Keypair,
-    dapp: AddressBookEntry,
+    dapp: DAppBookEntry,
     inner_instructions: Vec<Instruction>,
     inner_multisig_op_account: Keypair,
 }
@@ -54,9 +54,9 @@ async fn setup_dapp_test() -> DAppTest {
     .await;
 
     let inner_multisig_op_account = Keypair::new();
-    let dapp = AddressBookEntry {
+    let dapp = DAppBookEntry {
         address: context.program_id.clone(),
-        name_hash: AddressBookEntryNameHash::new(&hash_of(b"Strike Wallet")),
+        name_hash: DAppBookEntryNameHash::new(&hash_of(b"Strike Wallet")),
     };
 
     let inner_instructions = vec![
@@ -391,9 +391,9 @@ async fn test_dapp_transaction_with_spl_transfers() {
         .unwrap(),
     ];
 
-    let dapp = AddressBookEntry {
+    let dapp = DAppBookEntry {
         address: context.program_id.clone(),
-        name_hash: AddressBookEntryNameHash::new(&hash_of(b"Strike Wallet")),
+        name_hash: DAppBookEntryNameHash::new(&hash_of(b"Strike Wallet")),
     };
 
     context
@@ -462,9 +462,9 @@ async fn test_dapp_transaction_without_dapps_enabled() {
     let rent = context.banks_client.get_rent().await.unwrap();
     let multisig_account_rent = rent.minimum_balance(MultisigOp::LEN);
     let multisig_op_account = Keypair::new();
-    let dapp = AddressBookEntry {
+    let dapp = DAppBookEntry {
         address: context.program_id.clone(),
-        name_hash: AddressBookEntryNameHash::new(&hash_of(b"Strike Wallet")),
+        name_hash: DAppBookEntryNameHash::new(&hash_of(b"Strike Wallet")),
     };
     assert_eq!(
         context
@@ -519,9 +519,9 @@ async fn test_dapp_transaction_unwhitelisted() {
     let rent = context.banks_client.get_rent().await.unwrap();
     let multisig_account_rent = rent.minimum_balance(MultisigOp::LEN);
     let multisig_op_account = Keypair::new();
-    let dapp = AddressBookEntry {
+    let dapp = DAppBookEntry {
         address: context.program_id.clone(),
-        name_hash: AddressBookEntryNameHash::new(&hash_of(b"Strike Wallet")),
+        name_hash: DAppBookEntryNameHash::new(&hash_of(b"Strike Wallet")),
     };
     assert_eq!(
         context


### PR DESCRIPTION
## Description
Added a DAppBookUpdate instruction which lets dapps be added or removed from the dapp book. Added a dapp parameter (the address book entry for the dapp) to the init dapp transaction instruction and check it against the dapp book if whitelisting is on. The approval client can choose to validate if the dapp instructions are appropriate given the dapp, but we don't try to do that on-chain. Possibly we should pass the slotid for the dapp parameter too.

## Motivation and Context
DApp book provides a wallet-level way to control which dapps are allowed.

## How Has This Been Tested?
Added happy path unit test for dapp book update and to test whitelisting behavior of dapp transactions. Since implementation of the dapp book is the same as for the address book, I did not add duplicative error case tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New breaking feature (breaking change which adds functionality)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

