### PR TITLE
fix for wallet account serialization

### DIFF
--- a/src/model/wallet.rs
+++ b/src/model/wallet.rs
@@ -620,9 +620,9 @@ impl Pack for Wallet {
         1 + // approvals_required_for_config
         8 + // approval_timeout_for_config
         Approvers::STORAGE_SIZE + // config approvers
-        1 + BalanceAccount::LEN * Wallet::MAX_BALANCE_ACCOUNTS + // balance accounts with size
         1 + // config_policy_update_locked
-        DAppBook::LEN;
+        DAppBook::LEN +
+        1 + BalanceAccount::LEN * Wallet::MAX_BALANCE_ACCOUNTS; // balance accounts with size
 
     fn pack_into_slice(&self, dst: &mut [u8]) {
         let dst = array_mut_ref![dst, 0, Wallet::LEN];
@@ -634,10 +634,10 @@ impl Pack for Wallet {
             approvals_required_for_config_dst,
             approval_timeout_for_config_dst,
             config_approvers_dst,
-            balance_accounts_count_dst,
-            balance_accounts_dst,
             config_policy_update_locked_dst,
             dapp_book_dst,
+            balance_accounts_count_dst,
+            balance_accounts_dst,
         ) = mut_array_refs![
             dst,
             1,
@@ -648,9 +648,9 @@ impl Pack for Wallet {
             8,
             Approvers::STORAGE_SIZE,
             1,
-            BalanceAccount::LEN * Wallet::MAX_BALANCE_ACCOUNTS,
+            DAppBook::LEN,
             1,
-            DAppBook::LEN
+            BalanceAccount::LEN * Wallet::MAX_BALANCE_ACCOUNTS
         ];
 
         is_initialized_dst[0] = self.is_initialized as u8;
@@ -686,10 +686,10 @@ impl Pack for Wallet {
             approvals_required_for_config,
             approval_timeout_for_config,
             config_approvers_src,
-            balance_accounts_count,
-            balance_accounts_src,
             config_policy_update_locked_src,
             dapp_book_src,
+            balance_accounts_count,
+            balance_accounts_src,
         ) = array_refs![
             src,
             1,
@@ -700,9 +700,9 @@ impl Pack for Wallet {
             8,
             Approvers::STORAGE_SIZE,
             1,
-            BalanceAccount::LEN * Wallet::MAX_BALANCE_ACCOUNTS,
+            DAppBook::LEN,
             1,
-            DAppBook::LEN
+            BalanceAccount::LEN * Wallet::MAX_BALANCE_ACCOUNTS
         ];
 
         let mut balance_accounts = Vec::with_capacity(Wallet::MAX_BALANCE_ACCOUNTS);


### PR DESCRIPTION
Wallet account serialization is a little broken because it reserves more space for balance account config than it uses, so fields stored after the balance account config are stored in the wrong location. We should change it to use the same slot mechanism as the address book and signers, but in the interim, we can just move the fields serialized after the balance accounts to before.

## Description

## Motivation and Context

## How Has This Been Tested?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

