### PR TITLE
fix bug in dapp transaction instruction serialization

### DIFF
--- a/src/model/multisig_op.rs
+++ b/src/model/multisig_op.rs
@@ -651,10 +651,10 @@ impl MultisigOpParams {
                 bytes.push(7);
                 bytes.extend_from_slice(&wallet_address.to_bytes());
                 bytes.extend_from_slice(&account_guid_hash.to_bytes());
-                bytes.put_u16_le(instructions.len().as_u16());
                 let mut buf = vec![0; DAppBookEntry::LEN];
                 dapp.pack_into_slice(buf.as_mut_slice());
                 bytes.extend_from_slice(&buf[..]);
+                bytes.put_u16_le(instructions.len().as_u16());
                 for instruction in instructions.into_iter() {
                     append_instruction(instruction, &mut bytes);
                 }


### PR DESCRIPTION
The u16 for count of instructions should be right before the instructions, but it wasn't.

## How Has This Been Tested?
All tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

