### PR TITLE
Change dapp instructions to reduce transaction size

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -21,7 +21,7 @@ use crate::serialization_utils::{
     read_fixed_size_array, read_optional_duration, read_optional_u8, read_slice, read_u16, read_u8,
     unpack_option,
 };
-use crate::utils::SlotId;
+use crate::utils::{unique_account_metas, SlotId};
 
 #[derive(Debug)]
 pub enum ProgramInstruction {
@@ -376,9 +376,24 @@ impl ProgramInstruction {
                 let mut buf2 = vec![0; DAppBookEntry::LEN];
                 dapp.pack_into_slice(buf2.as_mut_slice());
                 buf.extend_from_slice(&buf2[..]);
+                let account_metas = unique_account_metas(instructions, &Vec::new());
+                buf.put_u8(account_metas.len().as_u8());
+                for account_meta in account_metas.iter() {
+                    let mut account_meta_buf = vec![0; 1 + Signer::LEN];
+                    account_meta_buf[0] = 0;
+                    if account_meta.is_signer {
+                        account_meta_buf[0] |= 2;
+                    }
+                    if account_meta.is_writable {
+                        account_meta_buf[0] |= 1;
+                    }
+                    Signer::new(account_meta.pubkey)
+                        .pack_into_slice(&mut account_meta_buf[1..1 + Signer::LEN]);
+                    buf.extend_from_slice(account_meta_buf.as_slice());
+                }
                 buf.put_u16_le(instructions.len() as u16);
                 for instruction in instructions.iter() {
-                    append_instruction(instruction, &mut buf);
+                    append_instruction(instruction, &account_metas, &mut buf);
                 }
             }
             &ProgramInstruction::FinalizeDAppTransaction {
@@ -391,9 +406,24 @@ impl ProgramInstruction {
                 let mut buf2 = vec![0; DAppBookEntry::LEN];
                 dapp.pack_into_slice(buf2.as_mut_slice());
                 buf.extend_from_slice(&buf2[..]);
+                let account_metas = unique_account_metas(instructions, &Vec::new());
+                buf.put_u8(account_metas.len().as_u8());
+                for account_meta in account_metas.iter() {
+                    let mut account_meta_buf = vec![0; 1 + Signer::LEN];
+                    account_meta_buf[0] = 0;
+                    if account_meta.is_signer {
+                        account_meta_buf[0] |= 2;
+                    }
+                    if account_meta.is_writable {
+                        account_meta_buf[0] |= 1;
+                    }
+                    Signer::new(account_meta.pubkey)
+                        .pack_into_slice(&mut account_meta_buf[1..1 + Signer::LEN]);
+                    buf.extend_from_slice(account_meta_buf.as_slice());
+                }
                 buf.put_u16_le(instructions.len() as u16);
                 for instruction in instructions.iter() {
-                    append_instruction(instruction, &mut buf);
+                    append_instruction(instruction, &account_metas, &mut buf);
                 }
             }
             &ProgramInstruction::InitAccountSettingsUpdate {
@@ -1097,13 +1127,40 @@ fn append_signers(signers: &Vec<(SlotId<Signer>, Signer)>, dst: &mut Vec<u8>) {
 }
 
 fn read_instructions(iter: &mut Iter<u8>) -> Result<Vec<Instruction>, ProgramError> {
+    let account_meta_count = read_u8(iter).ok_or(ProgramError::InvalidInstructionData)?;
+    let account_metas = (0..*account_meta_count)
+        .map(|_| read_account_meta(iter).unwrap())
+        .collect();
+
     let instruction_count = read_u16(iter).ok_or(ProgramError::InvalidInstructionData)?;
     Ok((0..instruction_count)
-        .map(|_| read_instruction(iter).unwrap())
+        .map(|_| read_instruction(iter, &account_metas).unwrap())
         .collect())
 }
 
-fn read_instruction(iter: &mut Iter<u8>) -> Result<Instruction, ProgramError> {
+fn read_account_meta(iter: &mut Iter<u8>) -> Result<AccountMeta, ProgramError> {
+    let flags = *read_u8(iter)
+        .ok_or(ProgramError::InvalidInstructionData)
+        .unwrap();
+    let pubkey = Pubkey::new(
+        read_slice(iter, 32)
+            .ok_or(ProgramError::InvalidInstructionData)
+            .unwrap()
+            .try_into()
+            .ok()
+            .unwrap(),
+    );
+    Ok(AccountMeta {
+        is_writable: (flags & 1) == 1,
+        is_signer: (flags & 2) == 2,
+        pubkey,
+    })
+}
+
+fn read_instruction(
+    iter: &mut Iter<u8>,
+    account_metas: &Vec<AccountMeta>,
+) -> Result<Instruction, ProgramError> {
     let program_id = Pubkey::new(
         read_slice(iter, 32)
             .ok_or(ProgramError::InvalidInstructionData)?
@@ -1112,22 +1169,10 @@ fn read_instruction(iter: &mut Iter<u8>) -> Result<Instruction, ProgramError> {
     let account_count = read_u16(iter).ok_or(ProgramError::InvalidInstructionData)?;
     let accounts = (0..account_count)
         .map(|_| {
-            let flags = *read_u8(iter)
+            let index = *read_u8(iter)
                 .ok_or(ProgramError::InvalidInstructionData)
                 .unwrap();
-            let pubkey = Pubkey::new(
-                read_slice(iter, 32)
-                    .ok_or(ProgramError::InvalidInstructionData)
-                    .unwrap()
-                    .try_into()
-                    .ok()
-                    .unwrap(),
-            );
-            AccountMeta {
-                is_writable: (flags & 1) == 1,
-                is_signer: (flags & 2) == 2,
-                pubkey,
-            }
+            account_metas[index.as_usize()].clone()
         })
         .collect();
     let data_len = read_u16(iter).ok_or(ProgramError::InvalidInstructionData)?;
@@ -1141,7 +1186,25 @@ fn read_instruction(iter: &mut Iter<u8>) -> Result<Instruction, ProgramError> {
     })
 }
 
-pub fn append_instruction(instruction: &Instruction, dst: &mut Vec<u8>) {
+pub fn append_instruction(
+    instruction: &Instruction,
+    account_metas: &Vec<AccountMeta>,
+    dst: &mut Vec<u8>,
+) {
+    dst.extend_from_slice(instruction.program_id.as_ref());
+    dst.put_u16_le(instruction.accounts.len() as u16);
+    for account in instruction.accounts.iter() {
+        let index = account_metas
+            .iter()
+            .position(|a| a.pubkey == account.pubkey)
+            .unwrap();
+        dst.put_u8(index.as_u8());
+    }
+    dst.put_u16_le(instruction.data.len().as_u16());
+    dst.extend_from_slice(instruction.data.as_slice());
+}
+
+pub fn append_instruction_with_account_metas(instruction: &Instruction, dst: &mut Vec<u8>) {
     dst.extend_from_slice(instruction.program_id.as_ref());
     dst.put_u16_le(instruction.accounts.len() as u16);
     for account in instruction.accounts.iter() {

--- a/src/model/multisig_op.rs
+++ b/src/model/multisig_op.rs
@@ -1,6 +1,6 @@
 use crate::error::WalletError;
 use crate::instruction::{
-    append_instruction_with_account_metas, AddressBookUpdate, BalanceAccountCreation,
+    append_instruction_expanded, AddressBookUpdate, BalanceAccountCreation,
     BalanceAccountPolicyUpdate, DAppBookUpdate, WalletConfigPolicyUpdate,
 };
 use crate::model::address_book::DAppBookEntry;
@@ -623,7 +623,7 @@ impl MultisigOpParams {
                 bytes.extend_from_slice(&buf[..]);
                 bytes.put_u16_le(instructions.len().as_u16());
                 for instruction in instructions.into_iter() {
-                    append_instruction_with_account_metas(instruction, &mut bytes);
+                    append_instruction_expanded(instruction, &mut bytes);
                 }
 
                 hash(&bytes)

--- a/src/model/multisig_op.rs
+++ b/src/model/multisig_op.rs
@@ -1,7 +1,7 @@
 use crate::error::WalletError;
 use crate::instruction::{
-    append_instruction, AddressBookUpdate, BalanceAccountCreation, BalanceAccountPolicyUpdate,
-    DAppBookUpdate, WalletConfigPolicyUpdate,
+    append_instruction_with_account_metas, AddressBookUpdate, BalanceAccountCreation,
+    BalanceAccountPolicyUpdate, DAppBookUpdate, WalletConfigPolicyUpdate,
 };
 use crate::model::address_book::DAppBookEntry;
 use crate::model::balance_account::{BalanceAccountGuidHash, BalanceAccountNameHash};
@@ -623,7 +623,7 @@ impl MultisigOpParams {
                 bytes.extend_from_slice(&buf[..]);
                 bytes.put_u16_le(instructions.len().as_u16());
                 for instruction in instructions.into_iter() {
-                    append_instruction(instruction, &mut bytes);
+                    append_instruction_with_account_metas(instruction, &mut bytes);
                 }
 
                 hash(&bytes)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,8 +6,11 @@ use std::ops::Index;
 use bitvec::prelude::*;
 use bitvec::slice::IterOnes;
 use itertools::Itertools;
+use solana_program::instruction::{AccountMeta, Instruction};
 use solana_program::program_error::ProgramError;
 use solana_program::program_pack::{Pack, Sealed};
+use solana_program::pubkey::Pubkey;
+use std::collections::BTreeMap;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct SlotId<A> {
@@ -227,4 +230,36 @@ impl<A> GetSlotIds<A> for Vec<(SlotId<A>, A)> {
     fn slot_ids(&self) -> Vec<&SlotId<A>> {
         self.iter().map(|(slot_id, _)| slot_id).collect_vec()
     }
+}
+
+pub fn unique_account_metas(
+    instructions: &Vec<Instruction>,
+    keys_to_skip: &Vec<Pubkey>,
+) -> Vec<AccountMeta> {
+    let mut accounts_by_key: BTreeMap<&Pubkey, AccountMeta> = BTreeMap::new();
+
+    for instruction in instructions.iter() {
+        accounts_by_key.insert(
+            &instruction.program_id,
+            AccountMeta {
+                pubkey: instruction.program_id,
+                is_writable: false,
+                is_signer: false,
+            },
+        );
+        for account in instruction.accounts.iter() {
+            if !keys_to_skip.contains(&account.pubkey) {
+                if accounts_by_key.contains_key(&account.pubkey) {
+                    // if the account was already in the map, make sure we do not downgrade its
+                    // permissions
+                    let meta = accounts_by_key.get_mut(&account.pubkey).unwrap();
+                    meta.is_writable |= account.is_writable;
+                    meta.is_signer |= account.is_signer
+                } else {
+                    accounts_by_key.insert(&account.pubkey, account.clone());
+                }
+            }
+        }
+    }
+    accounts_by_key.values().cloned().collect()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -261,5 +261,9 @@ pub fn unique_account_metas(
             }
         }
     }
-    accounts_by_key.values().cloned().collect()
+    accounts_by_key
+        .values()
+        .cloned()
+        .sorted_by(|a, b| a.pubkey.to_bytes().cmp(&b.pubkey.to_bytes()))
+        .collect()
 }

--- a/tests/common/instructions.rs
+++ b/tests/common/instructions.rs
@@ -587,7 +587,7 @@ pub fn finalize_dapp_transaction(
     ];
 
     // we also need to include any accounts referenced by the dapp instructions, but we don't
-    // want to repeat keys, so we'll use a BTreeMap to keep track of the ones we've already seen
+    // want to repeat keys
     let keys_to_skip = vec![
         *multisig_op_account,
         *wallet_account,

--- a/tests/common/instructions.rs
+++ b/tests/common/instructions.rs
@@ -4,7 +4,6 @@ use solana_program::instruction::{AccountMeta, Instruction};
 use solana_program::pubkey::Pubkey;
 use solana_program::{system_program, sysvar};
 use std::borrow::Borrow;
-use std::collections::BTreeMap;
 use std::time::Duration;
 use strike_wallet::instruction::{BalanceAccountCreation, BalanceAccountPolicyUpdate};
 use strike_wallet::{
@@ -18,6 +17,7 @@ use strike_wallet::{
         multisig_op::{ApprovalDisposition, BooleanSetting, SlotUpdateType, WrapDirection},
         signer::Signer,
     },
+    utils,
     utils::SlotId,
 };
 
@@ -596,32 +596,7 @@ pub fn finalize_dapp_transaction(
         sysvar::clock::id(),
     ];
 
-    let mut accounts_by_key: BTreeMap<&Pubkey, AccountMeta> = BTreeMap::new();
-
-    for instruction in instructions.iter() {
-        accounts_by_key.insert(
-            &instruction.program_id,
-            AccountMeta {
-                pubkey: instruction.program_id,
-                is_writable: false,
-                is_signer: false,
-            },
-        );
-        for account in instruction.accounts.iter() {
-            if !keys_to_skip.contains(&account.pubkey) {
-                if accounts_by_key.contains_key(&account.pubkey) {
-                    // if the account was already in the map, make sure we do not downgrade its
-                    // permissions
-                    let meta = accounts_by_key.get_mut(&account.pubkey).unwrap();
-                    meta.is_writable |= account.is_writable;
-                    meta.is_signer |= account.is_signer
-                } else {
-                    accounts_by_key.insert(&account.pubkey, account.clone());
-                }
-            }
-        }
-    }
-    accounts.extend(accounts_by_key.values().into_iter().cloned());
+    accounts.extend(utils::unique_account_metas(&instructions, &keys_to_skip));
 
     Instruction {
         program_id: *program_id,


### PR DESCRIPTION
## Description
The naive serialization of dapp instructions results in transactions being too large. Change the serialization to put the unique account metas first, and then reference the account meta in each instruction with just an index into that list.

## Motivation and Context
Real-world dapp transactions were not fitting into the solana transaction size limit.

## How Has This Been Tested?
All existing unit tests still pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Bug fix breaking (fix that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

