### PR TITLE
added multisig data account for dapp transactions

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -155,9 +155,10 @@ pub enum ProgramInstruction {
     FinalizeWalletConfigPolicyUpdate { update: WalletConfigPolicyUpdate },
 
     /// 0. `[writable]` The multisig operation account
-    /// 1. `[]` The wallet account
-    /// 2. `[signer]` The initiator account (either the transaction assistant or an approver)
-    /// 3. `[]` The sysvar clock account
+    /// 1. `[writable]` The multisig data account
+    /// 2. `[]` The wallet account
+    /// 3. `[signer]` The initiator account (either the transaction assistant or an approver)
+    /// 4. `[]` The sysvar clock account
     InitDAppTransaction {
         account_guid_hash: BalanceAccountGuidHash,
         instructions: Vec<Instruction>,
@@ -165,10 +166,11 @@ pub enum ProgramInstruction {
     },
 
     /// 0. `[writable]` The multisig operation account
-    /// 1. `[]` The wallet account
-    /// 2. `[writable]` The balance account
-    /// 3. `[signer]` The rent collector account
-    /// 4. `[]` The sysvar clock account
+    /// 1. `[writable]` The multisig data account
+    /// 2. `[]` The wallet account
+    /// 3. `[writable]` The balance account
+    /// 4. `[signer]` The rent collector account
+    /// 5. `[]` The sysvar clock account
     FinalizeDAppTransaction {
         account_guid_hash: BalanceAccountGuidHash,
         instructions: Vec<Instruction>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,6 @@
 pub mod address_book;
 pub mod balance_account;
+pub mod dapp_multisig_data;
 pub mod multisig_op;
 pub mod signer;
 pub mod wallet;

--- a/src/model/dapp_multisig_data.rs
+++ b/src/model/dapp_multisig_data.rs
@@ -1,0 +1,244 @@
+use crate::model::address_book::DAppBookEntry;
+use crate::model::balance_account::BalanceAccountGuidHash;
+use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
+use solana_program::entrypoint::ProgramResult;
+use solana_program::program_error::ProgramError;
+use solana_program::program_pack::{IsInitialized, Pack, Sealed};
+use solana_program::pubkey::{Pubkey, PUBKEY_BYTES};
+
+const INSTRUCTION_DATA_LEN: usize = 2500;
+const MAX_INSTRUCTION_COUNT: usize = 32;
+
+#[derive(Debug)]
+pub struct DAppMultisigData {
+    pub is_initialized: bool,
+    pub wallet_address: Pubkey,
+    pub account_guid_hash: BalanceAccountGuidHash,
+    pub dapp: DAppBookEntry,
+    pub num_instructions: u16,
+    instruction_offsets: [u16; MAX_INSTRUCTION_COUNT],
+    instruction_data: Vec<u8>,
+}
+
+impl DAppMultisigData {
+    pub fn init(
+        &mut self,
+        wallet_address: Pubkey,
+        account_guid_hash: BalanceAccountGuidHash,
+        dapp: DAppBookEntry,
+        num_instructions: u16,
+    ) -> ProgramResult {
+        self.is_initialized = true;
+        self.wallet_address = wallet_address;
+        self.account_guid_hash = account_guid_hash;
+        self.dapp = dapp;
+        if num_instructions > MAX_INSTRUCTION_COUNT as u16 {
+            panic!("Too many instructions")
+        }
+        self.num_instructions = num_instructions;
+        self.instruction_offsets = [0; MAX_INSTRUCTION_COUNT];
+        self.instruction_data = vec![0; INSTRUCTION_DATA_LEN];
+
+        Ok(())
+    }
+}
+
+impl Sealed for DAppMultisigData {}
+
+impl IsInitialized for DAppMultisigData {
+    fn is_initialized(&self) -> bool {
+        self.is_initialized
+    }
+}
+
+impl Pack for DAppMultisigData {
+    const LEN: usize = 1
+        + PUBKEY_BYTES
+        + 32
+        + DAppBookEntry::LEN
+        + 2
+        + 2 * MAX_INSTRUCTION_COUNT
+        + INSTRUCTION_DATA_LEN;
+
+    fn pack_into_slice(&self, dst: &mut [u8]) {
+        let dst = array_mut_ref![dst, 0, DAppMultisigData::LEN];
+        let (
+            is_initialized_dst,
+            wallet_address_dst,
+            account_guid_hash_dst,
+            dapp_dst,
+            num_instructions_dst,
+            instruction_offsets_dst,
+            instruction_data_dst,
+        ) = mut_array_refs![
+            dst,
+            1,
+            PUBKEY_BYTES,
+            32,
+            DAppBookEntry::LEN,
+            2,
+            2 * MAX_INSTRUCTION_COUNT,
+            INSTRUCTION_DATA_LEN
+        ];
+
+        let DAppMultisigData {
+            is_initialized,
+            wallet_address,
+            account_guid_hash,
+            dapp,
+            num_instructions,
+            instruction_offsets,
+            instruction_data,
+        } = self;
+
+        is_initialized_dst[0] = *is_initialized as u8;
+        *wallet_address_dst = wallet_address.to_bytes();
+        account_guid_hash_dst.copy_from_slice(account_guid_hash.to_bytes());
+        dapp.pack_into_slice(dapp_dst);
+        *num_instructions_dst = num_instructions.to_le_bytes();
+        instruction_offsets_dst
+            .chunks_exact_mut(2)
+            .take(MAX_INSTRUCTION_COUNT)
+            .enumerate()
+            .for_each(|(i, chunk)| {
+                chunk[0] = (instruction_offsets[i] & 0xFF) as u8;
+                chunk[1] = ((instruction_offsets[i] & 0xFF00) >> 8) as u8;
+            });
+        instruction_data_dst.copy_from_slice(instruction_data);
+    }
+
+    fn unpack_from_slice(src: &[u8]) -> Result<Self, ProgramError> {
+        let src = array_ref![src, 0, DAppMultisigData::LEN];
+        let (
+            is_initialized,
+            wallet_address,
+            account_guid_hash,
+            dapp,
+            num_instructions,
+            instruction_offsets,
+            instruction_data,
+        ) = array_refs![
+            src,
+            1,
+            PUBKEY_BYTES,
+            32,
+            DAppBookEntry::LEN,
+            2,
+            2 * MAX_INSTRUCTION_COUNT,
+            INSTRUCTION_DATA_LEN
+        ];
+
+        let is_initialized = match is_initialized {
+            [0] => false,
+            [1] => true,
+            _ => return Err(ProgramError::InvalidAccountData),
+        };
+
+        let mut instruction_offsets_array: [u16; MAX_INSTRUCTION_COUNT] =
+            [0; MAX_INSTRUCTION_COUNT];
+
+        instruction_offsets
+            .chunks_exact(2)
+            .enumerate()
+            .for_each(|(i, chunk)| {
+                instruction_offsets_array[i] = u16::from_le_bytes([chunk[0], chunk[1]])
+            });
+
+        let wallet_address = Pubkey::new_from_array(*wallet_address);
+        let account_guid_hash = BalanceAccountGuidHash::new(account_guid_hash);
+        let dapp = DAppBookEntry::unpack_from_slice(dapp).unwrap();
+        let num_instructions = u16::from_le_bytes(*num_instructions);
+
+        Ok(DAppMultisigData {
+            is_initialized,
+            wallet_address,
+            account_guid_hash,
+            dapp,
+            num_instructions,
+            instruction_offsets: instruction_offsets_array,
+            instruction_data: instruction_data[..].to_owned(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::model::address_book::{DAppBookEntry, DAppBookEntryNameHash};
+    use crate::model::balance_account::BalanceAccountGuidHash;
+    use crate::model::dapp_multisig_data::{DAppMultisigData, INSTRUCTION_DATA_LEN};
+    use arrayref::array_ref;
+    use sha2::Digest;
+    use sha2::Sha256;
+    use solana_program::program_pack::Pack;
+    use solana_program::pubkey::Pubkey;
+
+    fn hash_of(data: &[u8]) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        let hash_output = hasher.finalize();
+        *array_ref![hash_output, 0, 32]
+    }
+
+    #[test]
+    fn test_pack_unpack_empty() {
+        let data = DAppMultisigData {
+            is_initialized: false,
+            wallet_address: Pubkey::new(&[0; 32]),
+            account_guid_hash: BalanceAccountGuidHash::new(&[0; 32]),
+            dapp: DAppBookEntry {
+                address: Pubkey::new(&[0; 32]),
+                name_hash: DAppBookEntryNameHash::new(&[0; 32]),
+            },
+            num_instructions: 0,
+            instruction_offsets: [0; 32],
+            instruction_data: vec![0; INSTRUCTION_DATA_LEN],
+        };
+        let mut buffer = vec![0; DAppMultisigData::LEN];
+        data.pack_into_slice(&mut buffer);
+        let data2 = DAppMultisigData::unpack_from_slice(&buffer).unwrap();
+        compare_data(data, data2);
+    }
+
+    #[test]
+    fn test_pack_unpack_initialized() {
+        let data = DAppMultisigData {
+            is_initialized: true,
+            wallet_address: Pubkey::new_unique(),
+            account_guid_hash: BalanceAccountGuidHash::new(&hash_of(b"account-guid")),
+            dapp: DAppBookEntry {
+                address: Pubkey::new_unique(),
+                name_hash: DAppBookEntryNameHash::new(&hash_of(b"dapp-name")),
+            },
+            num_instructions: 3,
+            instruction_offsets: [
+                1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
+            ],
+            instruction_data: vec![1; INSTRUCTION_DATA_LEN],
+        };
+        let mut buffer = vec![0; DAppMultisigData::LEN];
+        data.pack_into_slice(&mut buffer);
+        let data2 = DAppMultisigData::unpack_from_slice(&buffer).unwrap();
+        compare_data(data, data2);
+    }
+
+    fn compare_data(data: DAppMultisigData, data2: DAppMultisigData) {
+        assert_eq!(data.is_initialized, data2.is_initialized);
+        assert_eq!(
+            data.wallet_address.to_bytes(),
+            data2.wallet_address.to_bytes()
+        );
+        assert_eq!(
+            data.account_guid_hash.to_bytes(),
+            data2.account_guid_hash.to_bytes()
+        );
+        assert_eq!(data.dapp.address.to_bytes(), data2.dapp.address.to_bytes());
+        assert_eq!(
+            data.dapp.name_hash.to_bytes(),
+            data2.dapp.name_hash.to_bytes()
+        );
+        assert_eq!(data.num_instructions, data2.num_instructions);
+        assert_eq!(data.instruction_offsets, data2.instruction_offsets);
+        assert_eq!(data.instruction_data, data2.instruction_data);
+    }
+}

--- a/src/model/dapp_multisig_data.rs
+++ b/src/model/dapp_multisig_data.rs
@@ -101,8 +101,7 @@ impl Pack for DAppMultisigData {
             .take(MAX_INSTRUCTION_COUNT)
             .enumerate()
             .for_each(|(i, chunk)| {
-                chunk[0] = (instruction_offsets[i] & 0xFF) as u8;
-                chunk[1] = ((instruction_offsets[i] & 0xFF00) >> 8) as u8;
+                chunk.copy_from_slice(&instruction_offsets[i].to_le_bytes()[..2]);
             });
         instruction_data_dst.copy_from_slice(instruction_data);
     }

--- a/tests/common/instructions.rs
+++ b/tests/common/instructions.rs
@@ -535,6 +535,7 @@ pub fn init_dapp_transaction(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
     multisig_op_account: &Pubkey,
+    multisig_data_account: &Pubkey,
     initiator_account: &Pubkey,
     account_guid_hash: &BalanceAccountGuidHash,
     dapp: DAppBookEntry,
@@ -550,6 +551,7 @@ pub fn init_dapp_transaction(
 
     let accounts = vec![
         AccountMeta::new(*multisig_op_account, false),
+        AccountMeta::new(*multisig_data_account, false),
         AccountMeta::new_readonly(*wallet_account, false),
         AccountMeta::new_readonly(*initiator_account, true),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
@@ -566,6 +568,7 @@ pub fn finalize_dapp_transaction(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
     multisig_op_account: &Pubkey,
+    multisig_data_account: &Pubkey,
     balance_account: &Pubkey,
     rent_collector_account: &Pubkey,
     account_guid_hash: &BalanceAccountGuidHash,
@@ -583,6 +586,7 @@ pub fn finalize_dapp_transaction(
     // the accounts below are expected below in this order by finalize
     let mut accounts = vec![
         AccountMeta::new(*multisig_op_account, false),
+        AccountMeta::new(*multisig_data_account, false),
         AccountMeta::new_readonly(*wallet_account, false),
         AccountMeta::new(*balance_account, false),
         AccountMeta::new(*rent_collector_account, true),
@@ -593,6 +597,7 @@ pub fn finalize_dapp_transaction(
     // want to repeat keys
     let keys_to_skip = vec![
         *multisig_op_account,
+        *multisig_data_account,
         *wallet_account,
         *balance_account,
         *rent_collector_account,


### PR DESCRIPTION
## Description
Added a multisig data account for dapp transaction init/finalize. In init, it is initialized with the data it would normally be initialized with, and in the finalize, the account is closed along with the multisig op account. Otherwise, it is not used.

## Motivation and Context
This is a step towards supporting multi-transaction initialization of dapp transaction multisig ops.


## How Has This Been Tested?
Existing tests all pass; also added a unit test for pack/unpack of the data account data model.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

