### PR TITLE
Remove dapp instruction compression

### DIFF
--- a/src/handlers/dapp_transaction_handler.rs
+++ b/src/handlers/dapp_transaction_handler.rs
@@ -8,10 +8,11 @@ use crate::handlers::utils::{
 use crate::model::address_book::DAppBookEntry;
 use crate::model::balance_account::BalanceAccountGuidHash;
 use crate::model::dapp_multisig_data::DAppMultisigData;
-use crate::model::multisig_op::{ApprovalDisposition, MultisigOp, MultisigOpParams};
+use crate::model::multisig_op::{ApprovalDisposition, MultisigOp, OperationDisposition};
 use crate::model::wallet::Wallet;
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
+use solana_program::hash::Hash;
 use solana_program::instruction::Instruction;
 use solana_program::msg;
 use solana_program::program::invoke_signed;
@@ -25,7 +26,7 @@ pub fn init(
     accounts: &[AccountInfo],
     account_guid_hash: &BalanceAccountGuidHash,
     dapp: DAppBookEntry,
-    instructions: Vec<Instruction>,
+    instruction_count: u8,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
     let multisig_op_account_info = next_program_account_info(accounts_iter, program_id)?;
@@ -49,8 +50,6 @@ pub fn init(
         }
     }
 
-    let instructions_len = instructions.len();
-
     let mut multisig_op = MultisigOp::unpack_unchecked(&multisig_op_account_info.data.borrow())?;
     multisig_op.init(
         wallet.get_transfer_approvers_keys(&balance_account),
@@ -61,12 +60,7 @@ pub fn init(
             clock.unix_timestamp,
             balance_account.approval_timeout_for_transfer,
         )?,
-        MultisigOpParams::DAppTransaction {
-            wallet_address: *wallet_account_info.key,
-            account_guid_hash: *account_guid_hash,
-            dapp,
-            instructions,
-        },
+        None,
     )?;
     MultisigOp::pack(multisig_op, &mut multisig_op_account_info.data.borrow_mut())?;
 
@@ -76,7 +70,7 @@ pub fn init(
         *wallet_account_info.key,
         *account_guid_hash,
         dapp,
-        instructions_len.as_u16(),
+        instruction_count,
     )?;
     DAppMultisigData::pack(
         multisig_data,
@@ -102,39 +96,58 @@ pub fn supply_instructions(
     }
     // TODO - once we are storing the initiator in the multisig op (PRIME-3999), verify that the supplied one matches
 
-    let mut multisig_op = MultisigOp::unpack_unchecked(&multisig_op_account_info.data.borrow())?;
+    let params_hash = {
+        let mut multisig_data =
+            DAppMultisigData::unpack_unchecked(&multisig_data_account_info.data.borrow())?;
 
-    if multisig_op.params_hash.is_some() {
-        //return Err(WalletError::DAppTransactionAlreadyInitialized);
-    }
-
-    let mut multisig_data =
-        DAppMultisigData::unpack_unchecked(&multisig_data_account_info.data.borrow())?;
-
-    for index in starting_index..starting_index + instructions.len().as_u8() {
-        multisig_data.add_instruction(
-            index.as_u16(),
-            &instructions
-                .get(usize::from(index - starting_index))
-                .unwrap(),
-        )?;
-    }
-
-    if multisig_data.all_instructions_supplied() {
-        // compute hash and store in multisig op
-        let params_hash = multisig_data.hash()?;
-
-        // this is just temporary while the params hash is still being calculated by init
-        if params_hash != multisig_op.params_hash.unwrap() {
-            panic!("HASHES DO NOT MATCH!!!");
+        for index in starting_index..starting_index + instructions.len().as_u8() {
+            multisig_data.add_instruction(
+                index,
+                &instructions
+                    .get(usize::from(index - starting_index))
+                    .unwrap(),
+            )?;
         }
-        multisig_op.params_hash = Some(params_hash);
+
+        let params_hash = if multisig_data.all_instructions_supplied() {
+            Some(multisig_data.hash()?)
+        } else {
+            None
+        };
+
+        DAppMultisigData::pack(
+            multisig_data,
+            &mut multisig_data_account_info.data.borrow_mut(),
+        )?;
+
+        params_hash
+    };
+
+    // separate block so memory from unpacking the data gets reused
+    if let Some(_) = params_hash {
+        let mut multisig_op =
+            MultisigOp::unpack_unchecked(&multisig_op_account_info.data.borrow())?;
+
+        multisig_op.params_hash = params_hash;
+
+        // record approval
+        if let Some(record) = multisig_op
+            .disposition_records
+            .iter_mut()
+            .find(|r| r.approver == *initiator_account_info.key)
+        {
+            if record.disposition == ApprovalDisposition::NONE {
+                record.disposition = ApprovalDisposition::APPROVE
+            }
+        }
+        if multisig_op.get_disposition_count(ApprovalDisposition::APPROVE)
+            == multisig_op.dispositions_required
+        {
+            multisig_op.operation_disposition = OperationDisposition::APPROVED
+        }
+
+        MultisigOp::pack(multisig_op, &mut multisig_op_account_info.data.borrow_mut())?;
     }
-    DAppMultisigData::pack(
-        multisig_data,
-        &mut multisig_data_account_info.data.borrow_mut(),
-    )?;
-    MultisigOp::pack(multisig_op, &mut multisig_op_account_info.data.borrow_mut())?;
 
     Ok(())
 }
@@ -226,13 +239,12 @@ pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     account_guid_hash: &BalanceAccountGuidHash,
-    dapp: DAppBookEntry,
-    instructions: &Vec<Instruction>,
+    params_hash: &Hash,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
     let multisig_op_account_info = next_program_account_info(accounts_iter, program_id)?;
     let multisig_data_account_info = next_program_account_info(accounts_iter, program_id)?;
-    let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
+    let _wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let balance_account = next_account_info(accounts_iter)?;
     let rent_collector_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
@@ -242,19 +254,16 @@ pub fn finalize(
     }
 
     let multisig_op = MultisigOp::unpack(&multisig_op_account_info.data.borrow())?;
+    let multisig_data = DAppMultisigData::unpack(&multisig_data_account_info.data.borrow())?;
 
-    let expected_params = MultisigOpParams::DAppTransaction {
-        wallet_address: *wallet_account_info.key,
-        account_guid_hash: *account_guid_hash,
-        instructions: instructions.clone(),
-        dapp,
-    };
-
-    const NOT_FINAL: u32 = WalletError::TransferDispositionNotFinal as u32;
-    let (is_approved, is_final) = match multisig_op.approved(&expected_params, &clock) {
-        Ok(a) => (a, true),
-        Err(ProgramError::Custom(NOT_FINAL)) => (false, false),
-        Err(e) => return Err(e),
+    let instructions = multisig_data.instructions()?;
+    let (is_approved, is_final) = {
+        const NOT_FINAL: u32 = WalletError::TransferDispositionNotFinal as u32;
+        match multisig_op.approved(multisig_data.hash()?, &clock, Some(params_hash)) {
+            Ok(a) => (a, true),
+            Err(ProgramError::Custom(NOT_FINAL)) => (false, false),
+            Err(e) => return Err(e),
+        }
     };
 
     let bump_seed =

--- a/src/handlers/utils.rs
+++ b/src/handlers/utils.rs
@@ -92,7 +92,7 @@ pub fn start_multisig_transfer_op(
             clock.unix_timestamp,
             balance_account.approval_timeout_for_transfer,
         )?,
-        params,
+        Some(params),
     )?;
     MultisigOp::pack(multisig_op, &mut multisig_op_account_info.data.borrow_mut())?;
 
@@ -114,7 +114,7 @@ pub fn start_multisig_config_op(
         wallet.approvals_required_for_config,
         clock.unix_timestamp,
         calculate_expires(clock.unix_timestamp, wallet.approval_timeout_for_config)?,
-        params,
+        Some(params),
     )?;
     MultisigOp::pack(multisig_op, &mut multisig_op_account_info.data.borrow_mut())?;
 
@@ -137,7 +137,7 @@ where
 
     let multisig_op = MultisigOp::unpack(&multisig_op_account_info.data.borrow())?;
 
-    if multisig_op.approved(&expected_params, &clock)? {
+    if multisig_op.approved(expected_params.hash(), &clock, None)? {
         on_op_approved()?
     }
 

--- a/src/model/dapp_multisig_data.rs
+++ b/src/model/dapp_multisig_data.rs
@@ -1,5 +1,5 @@
 use crate::error::WalletError;
-use crate::instruction::{append_instruction_expanded, read_expanded_instruction};
+use crate::instruction::{append_instruction, read_instruction};
 use crate::model::address_book::DAppBookEntry;
 use crate::model::balance_account::BalanceAccountGuidHash;
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
@@ -62,7 +62,7 @@ impl DAppMultisigData {
                 return Err(WalletError::DAppInstructionAlreadySupplied.into());
             }
             let mut buffer = Vec::<u8>::new();
-            append_instruction_expanded(instruction, &mut buffer);
+            append_instruction(instruction, &mut buffer);
             // the offset is 1-based, so that an offset of 0 can mean "unset"
             self.instruction_offsets[usize::from(index)] = (1 + self.position).as_u16();
             let new_position = self.position + buffer.len();
@@ -93,7 +93,7 @@ impl DAppMultisigData {
         let instructions = self.instructions()?;
         bytes.put_u16_le(instructions.len().as_u16());
         for instruction in instructions.into_iter() {
-            append_instruction_expanded(&instruction, &mut bytes);
+            append_instruction(&instruction, &mut bytes);
         }
 
         Ok(hash(&bytes))
@@ -103,7 +103,7 @@ impl DAppMultisigData {
         let read_nth_instruction = |index| -> Result<Instruction, ProgramError> {
             let offset = usize::from(self.instruction_offsets.get(usize::from(index)).unwrap() - 1);
             let bytes: Vec<u8> = self.instruction_data[offset..].to_vec();
-            read_expanded_instruction(&mut bytes.iter())
+            read_instruction(&mut bytes.iter())
         };
 
         Ok((0..self.num_instructions)

--- a/src/model/dapp_multisig_data.rs
+++ b/src/model/dapp_multisig_data.rs
@@ -1,5 +1,5 @@
 use crate::error::WalletError;
-use crate::instruction::{append_instruction, read_instruction};
+use crate::instruction::{append_instruction, read_instruction_from_slice};
 use crate::model::address_book::DAppBookEntry;
 use crate::model::balance_account::BalanceAccountGuidHash;
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
@@ -23,7 +23,7 @@ pub struct DAppMultisigData {
     pub wallet_address: Pubkey,
     pub account_guid_hash: BalanceAccountGuidHash,
     pub dapp: DAppBookEntry,
-    pub num_instructions: u16,
+    pub num_instructions: u8,
     instruction_offsets: [u16; MAX_INSTRUCTION_COUNT],
     instruction_data: Vec<u8>,
     position: usize,
@@ -35,13 +35,13 @@ impl DAppMultisigData {
         wallet_address: Pubkey,
         account_guid_hash: BalanceAccountGuidHash,
         dapp: DAppBookEntry,
-        num_instructions: u16,
+        num_instructions: u8,
     ) -> ProgramResult {
         self.is_initialized = true;
         self.wallet_address = wallet_address;
         self.account_guid_hash = account_guid_hash;
         self.dapp = dapp;
-        if num_instructions > MAX_INSTRUCTION_COUNT as u16 {
+        if num_instructions > MAX_INSTRUCTION_COUNT as u8 {
             return Err(WalletError::DAppInstructionOverflow.into());
         }
         self.num_instructions = num_instructions;
@@ -52,7 +52,7 @@ impl DAppMultisigData {
         Ok(())
     }
 
-    pub fn add_instruction(&mut self, index: u16, instruction: &Instruction) -> ProgramResult {
+    pub fn add_instruction(&mut self, index: u8, instruction: &Instruction) -> ProgramResult {
         if self.is_initialized {
             if index >= self.num_instructions {
                 msg!("Index {:} too large (>= {:})", index, self.num_instructions);
@@ -90,26 +90,37 @@ impl DAppMultisigData {
         let mut buf = vec![0; DAppBookEntry::LEN];
         self.dapp.pack_into_slice(buf.as_mut_slice());
         bytes.extend_from_slice(&buf[..]);
+        bytes.put_u16_le(self.num_instructions.as_u16());
+        // appending the instructions to this vec could use too much memory
+        // instead, we define the hash for a dapp transaction to be an iterated hash this way:
+        // first, take the hash of everything in `bytes` up to this point:
+        let mut result = hash(&bytes);
+        // then, for each instruction, form a buffer with the previous hash followed by that
+        // instruction, and then hash that
         let instructions = self.instructions()?;
-        bytes.put_u16_le(instructions.len().as_u16());
         for instruction in instructions.into_iter() {
-            append_instruction(&instruction, &mut bytes);
+            let mut instruction_buffer: Vec<u8> = Vec::new();
+            instruction_buffer.extend_from_slice(result.as_ref());
+            append_instruction(&instruction, &mut instruction_buffer);
+            result = hash(&instruction_buffer);
         }
 
-        Ok(hash(&bytes))
+        Ok(result)
     }
 
     pub fn instructions(&self) -> Result<Vec<Instruction>, ProgramError> {
         let read_nth_instruction = |index| -> Result<Instruction, ProgramError> {
-            let offset = usize::from(self.instruction_offsets.get(usize::from(index)).unwrap() - 1);
-            let bytes: Vec<u8> = self.instruction_data[offset..].to_vec();
-            read_instruction(&mut bytes.iter())
+            let instruction_offset = self.instruction_offsets.get(usize::from(index)).unwrap();
+            if *instruction_offset == 0 {
+                return Err(WalletError::OperationNotInitialized.into());
+            }
+            let offset = usize::from(instruction_offset - 1);
+            read_instruction_from_slice(&self.instruction_data[offset..])
         };
 
-        Ok((0..self.num_instructions)
+        (0..self.num_instructions)
             .map(read_nth_instruction)
-            .filter_map(|f| f.ok())
-            .collect())
+            .collect()
     }
 }
 
@@ -126,7 +137,7 @@ impl Pack for DAppMultisigData {
         + PUBKEY_BYTES
         + 32
         + DAppBookEntry::LEN
-        + 2
+        + 1
         + 2 * MAX_INSTRUCTION_COUNT
         + 2
         + INSTRUCTION_DATA_LEN;
@@ -148,7 +159,7 @@ impl Pack for DAppMultisigData {
             PUBKEY_BYTES,
             32,
             DAppBookEntry::LEN,
-            2,
+            1,
             2 * MAX_INSTRUCTION_COUNT,
             2,
             INSTRUCTION_DATA_LEN
@@ -169,7 +180,7 @@ impl Pack for DAppMultisigData {
         *wallet_address_dst = wallet_address.to_bytes();
         account_guid_hash_dst.copy_from_slice(account_guid_hash.to_bytes());
         dapp.pack_into_slice(dapp_dst);
-        *num_instructions_dst = num_instructions.to_le_bytes();
+        num_instructions_dst[0] = *num_instructions;
         instruction_offsets_dst
             .chunks_exact_mut(2)
             .take(MAX_INSTRUCTION_COUNT)
@@ -198,7 +209,7 @@ impl Pack for DAppMultisigData {
             PUBKEY_BYTES,
             32,
             DAppBookEntry::LEN,
-            2,
+            1,
             2 * MAX_INSTRUCTION_COUNT,
             2,
             INSTRUCTION_DATA_LEN
@@ -223,14 +234,13 @@ impl Pack for DAppMultisigData {
         let wallet_address = Pubkey::new_from_array(*wallet_address);
         let account_guid_hash = BalanceAccountGuidHash::new(account_guid_hash);
         let dapp = DAppBookEntry::unpack_from_slice(dapp).unwrap();
-        let num_instructions = u16::from_le_bytes(*num_instructions);
 
         Ok(DAppMultisigData {
             is_initialized,
             wallet_address,
             account_guid_hash,
             dapp,
-            num_instructions,
+            num_instructions: num_instructions[0],
             instruction_offsets: instruction_offsets_array,
             instruction_data: instruction_data[..].to_owned(),
             position: usize::from(u16::from_le_bytes(*position)),

--- a/src/model/multisig_op.rs
+++ b/src/model/multisig_op.rs
@@ -1,7 +1,7 @@
 use crate::error::WalletError;
 use crate::instruction::{
-    append_instruction_expanded, AddressBookUpdate, BalanceAccountCreation,
-    BalanceAccountPolicyUpdate, DAppBookUpdate, WalletConfigPolicyUpdate,
+    append_instruction, AddressBookUpdate, BalanceAccountCreation, BalanceAccountPolicyUpdate,
+    DAppBookUpdate, WalletConfigPolicyUpdate,
 };
 use crate::model::address_book::DAppBookEntry;
 use crate::model::balance_account::{BalanceAccountGuidHash, BalanceAccountNameHash};
@@ -650,7 +650,7 @@ impl MultisigOpParams {
                 bytes.extend_from_slice(&buf[..]);
                 bytes.put_u16_le(instructions.len().as_u16());
                 for instruction in instructions.into_iter() {
-                    append_instruction_expanded(instruction, &mut bytes);
+                    append_instruction(instruction, &mut bytes);
                 }
 
                 hash(&bytes)

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -176,13 +176,13 @@ impl Processor {
             ProgramInstruction::InitDAppTransaction {
                 ref account_guid_hash,
                 dapp,
-                instructions,
+                instruction_count,
             } => dapp_transaction_handler::init(
                 program_id,
                 accounts,
                 account_guid_hash,
                 dapp,
-                instructions,
+                instruction_count,
             ),
 
             ProgramInstruction::SupplyDAppTransactionInstructions {
@@ -197,14 +197,12 @@ impl Processor {
 
             ProgramInstruction::FinalizeDAppTransaction {
                 ref account_guid_hash,
-                dapp,
-                ref instructions,
+                ref params_hash,
             } => dapp_transaction_handler::finalize(
                 program_id,
                 accounts,
                 account_guid_hash,
-                dapp,
-                instructions,
+                params_hash,
             ),
 
             ProgramInstruction::InitAccountSettingsUpdate {

--- a/tests/address_book_update_tests.rs
+++ b/tests/address_book_update_tests.rs
@@ -11,7 +11,9 @@ use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
 use strike_wallet::error::WalletError;
 use strike_wallet::instruction::AddressBookUpdate;
-use strike_wallet::model::multisig_op::{ApprovalDisposition, ApprovalDispositionRecord, BooleanSetting, OperationDisposition};
+use strike_wallet::model::multisig_op::{
+    ApprovalDisposition, ApprovalDispositionRecord, BooleanSetting, OperationDisposition,
+};
 
 #[tokio::test]
 async fn test_address_book_update() {
@@ -198,10 +200,10 @@ async fn test_address_book_update_initiator_approval() {
             add_address_book_entries: vec![],
             remove_address_book_entries: wallet.address_book.filled_slots(),
             balance_account_whitelist_updates: vec![],
-        }
+        },
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     assert_multisig_op_dispositions(
         &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,
@@ -227,10 +229,10 @@ async fn test_address_book_update_initiator_approval() {
             add_address_book_entries: vec![],
             remove_address_book_entries: wallet.address_book.filled_slots(),
             balance_account_whitelist_updates: vec![],
-        }
+        },
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     assert_multisig_op_dispositions(
         &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,

--- a/tests/balance_account_transfer_tests.rs
+++ b/tests/balance_account_transfer_tests.rs
@@ -16,7 +16,9 @@ use solana_sdk::transaction::TransactionError;
 use common::instructions::finalize_transfer;
 use strike_wallet::error::WalletError;
 use strike_wallet::model::address_book::AddressBookEntryNameHash;
-use strike_wallet::model::multisig_op::{ApprovalDisposition, ApprovalDispositionRecord, BooleanSetting, OperationDisposition};
+use strike_wallet::model::multisig_op::{
+    ApprovalDisposition, ApprovalDispositionRecord, BooleanSetting, OperationDisposition,
+};
 use strike_wallet::utils::SlotId;
 use {
     solana_program::system_instruction,
@@ -29,8 +31,14 @@ async fn test_transfer_sol() {
     let (mut context, balance_account) = setup_balance_account_tests_and_finalize(None).await;
     let initiator = &Keypair::from_base58_string(&context.approvers[2].to_base58_string());
 
-    let (multisig_op_account, result) =
-        setup_transfer_test(context.borrow_mut(), initiator, &balance_account, None, None).await;
+    let (multisig_op_account, result) = setup_transfer_test(
+        context.borrow_mut(),
+        initiator,
+        &balance_account,
+        None,
+        None,
+    )
+    .await;
     result.unwrap();
 
     approve_or_deny_n_of_n_multisig_op(
@@ -123,8 +131,14 @@ async fn test_transfer_sol_denied() {
     let (mut context, balance_account) = setup_balance_account_tests_and_finalize(None).await;
     let initiator = &Keypair::from_base58_string(&context.approvers[2].to_base58_string());
 
-    let (multisig_op_account, result) =
-        setup_transfer_test(context.borrow_mut(), &initiator, &balance_account, None, None).await;
+    let (multisig_op_account, result) = setup_transfer_test(
+        context.borrow_mut(),
+        &initiator,
+        &balance_account,
+        None,
+        None,
+    )
+    .await;
     result.unwrap();
 
     approve_or_deny_n_of_n_multisig_op(
@@ -230,7 +244,14 @@ async fn test_transfer_wrong_destination_name_hash() {
 
     context.destination_name_hash = AddressBookEntryNameHash::zero();
 
-    let (_, result) = setup_transfer_test(context.borrow_mut(), &initiator, &balance_account, None, None).await;
+    let (_, result) = setup_transfer_test(
+        context.borrow_mut(),
+        &initiator,
+        &balance_account,
+        None,
+        None,
+    )
+    .await;
     assert_eq!(
         result.unwrap_err().unwrap(),
         TransactionError::InstructionError(1, Custom(WalletError::DestinationNotAllowed as u32)),
@@ -241,8 +262,14 @@ async fn test_transfer_wrong_destination_name_hash() {
 async fn test_transfer_requires_multisig() {
     let (mut context, balance_account) = setup_balance_account_tests_and_finalize(None).await;
     let initiator = &Keypair::from_base58_string(&context.approvers[2].to_base58_string());
-    let (multisig_op_account, result) =
-        setup_transfer_test(context.borrow_mut(), &initiator, &balance_account, None, None).await;
+    let (multisig_op_account, result) = setup_transfer_test(
+        context.borrow_mut(),
+        &initiator,
+        &balance_account,
+        None,
+        None,
+    )
+    .await;
     result.unwrap();
 
     approve_or_deny_1_of_2_multisig_op(
@@ -291,8 +318,14 @@ async fn test_transfer_requires_multisig() {
 async fn test_approval_fails_if_incorrect_params_hash() {
     let (mut context, balance_account) = setup_balance_account_tests_and_finalize(None).await;
     let initiator = &Keypair::from_base58_string(&context.approvers[2].to_base58_string());
-    let (multisig_op_account, result) =
-        setup_transfer_test(context.borrow_mut(), &initiator, &balance_account, None, None).await;
+    let (multisig_op_account, result) = setup_transfer_test(
+        context.borrow_mut(),
+        &initiator,
+        &balance_account,
+        None,
+        None,
+    )
+    .await;
     result.unwrap();
 
     assert_eq!(
@@ -321,8 +354,14 @@ async fn test_approval_fails_if_incorrect_params_hash() {
 async fn test_transfer_insufficient_balance() {
     let (mut context, balance_account) = setup_balance_account_tests_and_finalize(None).await;
     let initiator = &Keypair::from_base58_string(&context.approvers[2].to_base58_string());
-    let (multisig_op_account, result) =
-        setup_transfer_test(context.borrow_mut(), &initiator, &balance_account, None, None).await;
+    let (multisig_op_account, result) = setup_transfer_test(
+        context.borrow_mut(),
+        &initiator,
+        &balance_account,
+        None,
+        None,
+    )
+    .await;
     result.unwrap();
 
     approve_or_deny_n_of_n_multisig_op(
@@ -370,7 +409,14 @@ async fn test_transfer_unwhitelisted_address() {
     let initiator = &Keypair::from_base58_string(&context.approvers[2].to_base58_string());
     account_settings_update(&mut context, Some(BooleanSetting::On), None, None).await;
 
-    let (_, result) = setup_transfer_test(context.borrow_mut(), &initiator, &balance_account, None, None).await;
+    let (_, result) = setup_transfer_test(
+        context.borrow_mut(),
+        &initiator,
+        &balance_account,
+        None,
+        None,
+    )
+    .await;
     assert_eq!(
         result.unwrap_err().unwrap(),
         TransactionError::InstructionError(1, Custom(WalletError::DestinationNotAllowed as u32)),
@@ -382,8 +428,14 @@ async fn test_transfer_initiator_approval() {
     let (mut context, balance_account) = setup_balance_account_tests_and_finalize(None).await;
     let initiator = &Keypair::from_base58_string(&context.approvers[2].to_base58_string());
 
-    let (multisig_op_account, result) =
-        setup_transfer_test(context.borrow_mut(), initiator, &balance_account, None, None).await;
+    let (multisig_op_account, result) = setup_transfer_test(
+        context.borrow_mut(),
+        initiator,
+        &balance_account,
+        None,
+        None,
+    )
+    .await;
     result.unwrap();
 
     assert_multisig_op_dispositions(
@@ -405,8 +457,14 @@ async fn test_transfer_initiator_approval() {
     let (mut context, balance_account) = setup_balance_account_tests_and_finalize(None).await;
     let initiator = &Keypair::from_base58_string(&context.approvers[0].to_base58_string());
 
-    let (multisig_op_account, result) =
-        setup_transfer_test(context.borrow_mut(), initiator, &balance_account, None, None).await;
+    let (multisig_op_account, result) = setup_transfer_test(
+        context.borrow_mut(),
+        initiator,
+        &balance_account,
+        None,
+        None,
+    )
+    .await;
     result.unwrap();
 
     assert_multisig_op_dispositions(

--- a/tests/balance_account_update_tests.rs
+++ b/tests/balance_account_update_tests.rs
@@ -6,7 +6,7 @@ pub use common::instructions::*;
 pub use common::utils::*;
 
 use std::borrow::BorrowMut;
-use std::time::{Duration};
+use std::time::Duration;
 
 use solana_program::instruction::InstructionError::Custom;
 
@@ -18,7 +18,9 @@ use std::collections::HashSet;
 use strike_wallet::error::WalletError;
 use strike_wallet::instruction::BalanceAccountPolicyUpdate;
 use strike_wallet::model::balance_account::{BalanceAccountGuidHash, BalanceAccountNameHash};
-use strike_wallet::model::multisig_op::{ApprovalDisposition, ApprovalDispositionRecord, OperationDisposition};
+use strike_wallet::model::multisig_op::{
+    ApprovalDisposition, ApprovalDispositionRecord, OperationDisposition,
+};
 use strike_wallet::utils::SlotId;
 use {
     solana_program::system_instruction,
@@ -152,10 +154,10 @@ async fn test_balance_account_policy_update_initiator_approval() {
             approval_timeout_for_transfer: Some(Duration::from_secs(7200)),
             add_transfer_approvers: vec![],
             remove_transfer_approvers: vec![],
-        }
+        },
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     assert_multisig_op_dispositions(
         &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,
@@ -184,10 +186,10 @@ async fn test_balance_account_policy_update_initiator_approval() {
             approval_timeout_for_transfer: Some(Duration::from_secs(7200)),
             add_transfer_approvers: vec![],
             remove_transfer_approvers: vec![],
-        }
+        },
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     assert_multisig_op_dispositions(
         &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,
@@ -402,7 +404,7 @@ async fn test_balance_account_policy_update_is_denied() {
         &context.payer,
         context.recent_blockhash,
         ApprovalDisposition::DENY,
-        OperationDisposition::DENIED
+        OperationDisposition::DENIED,
     )
     .await;
 
@@ -642,9 +644,10 @@ async fn test_update_balance_account_name_initiator_approval() {
     let name_hash = BalanceAccountNameHash::new(&[1; 32]);
     let initiator_account = Keypair::from_base58_string(&context.approvers[2].to_base58_string());
 
-    let multisig_op = init_balance_account_name_hash_update(&mut context, &initiator_account, name_hash)
-        .await
-        .unwrap();
+    let multisig_op =
+        init_balance_account_name_hash_update(&mut context, &initiator_account, name_hash)
+            .await
+            .unwrap();
 
     assert_multisig_op_dispositions(
         &get_multisig_op_data(&mut context.banks_client, multisig_op).await,
@@ -666,9 +669,10 @@ async fn test_update_balance_account_name_initiator_approval() {
     let name_hash = BalanceAccountNameHash::new(&[1; 32]);
     let initiator_account = Keypair::from_base58_string(&context.approvers[0].to_base58_string());
 
-    let multisig_op = init_balance_account_name_hash_update(&mut context, &initiator_account, name_hash)
-        .await
-        .unwrap();
+    let multisig_op =
+        init_balance_account_name_hash_update(&mut context, &initiator_account, name_hash)
+            .await
+            .unwrap();
 
     assert_multisig_op_dispositions(
         &get_multisig_op_data(&mut context.banks_client, multisig_op).await,

--- a/tests/balance_account_update_whitelist_status_tests.rs
+++ b/tests/balance_account_update_whitelist_status_tests.rs
@@ -7,9 +7,9 @@ pub use common::utils::*;
 
 use solana_program::instruction::InstructionError::Custom;
 use solana_program_test::tokio;
+use solana_sdk::signature::Keypair;
 use solana_sdk::transaction::TransactionError;
 use std::borrow::BorrowMut;
-use solana_sdk::signature::Keypair;
 use strike_wallet::error::WalletError;
 use strike_wallet::model::{balance_account::BalanceAccountGuidHash, multisig_op::BooleanSetting};
 use strike_wallet::utils::SlotId;
@@ -28,8 +28,9 @@ async fn test_whitelist_status() {
         initiator,
         &balance_account,
         None,
-        None
-    ).await;
+        None,
+    )
+    .await;
     result.unwrap();
 
     // add a whitelisted destination, should fail since whitelisting on
@@ -81,8 +82,9 @@ async fn test_whitelist_status() {
         initiator,
         &balance_account,
         None,
-        None
-    ).await;
+        None,
+    )
+    .await;
     assert_eq!(
         result.unwrap_err().unwrap(),
         TransactionError::InstructionError(1, Custom(WalletError::DestinationNotAllowed as u32)),
@@ -98,8 +100,9 @@ async fn test_whitelist_status() {
         initiator,
         &balance_account,
         None,
-        None
-    ).await;
+        None,
+    )
+    .await;
     result.unwrap();
 
     // explicitly turn it on

--- a/tests/common/instructions.rs
+++ b/tests/common/instructions.rs
@@ -572,16 +572,10 @@ pub fn supply_dapp_transaction_instructions(
     multisig_data_account: &Pubkey,
     initiator_account: &Pubkey,
     starting_index: u8,
-    account_metas: &Vec<AccountMeta>,
     instructions: &Vec<Instruction>,
 ) -> Instruction {
     let mut data = Vec::<u8>::new();
-    pack_supply_dapp_transaction_instructions(
-        starting_index,
-        account_metas,
-        instructions,
-        &mut data,
-    );
+    pack_supply_dapp_transaction_instructions(starting_index, instructions, &mut data);
     let accounts = vec![
         AccountMeta::new(*multisig_op_account, false),
         AccountMeta::new(*multisig_data_account, false),

--- a/tests/common/instructions.rs
+++ b/tests/common/instructions.rs
@@ -541,12 +541,12 @@ pub fn init_dapp_transaction(
     initiator_account: &Pubkey,
     account_guid_hash: &BalanceAccountGuidHash,
     dapp: DAppBookEntry,
-    instructions: Vec<Instruction>,
+    instruction_count: u8,
 ) -> Instruction {
     let data = ProgramInstruction::InitDAppTransaction {
         account_guid_hash: *account_guid_hash,
         dapp,
-        instructions,
+        instruction_count,
     }
     .borrow()
     .pack();
@@ -597,13 +597,12 @@ pub fn finalize_dapp_transaction(
     balance_account: &Pubkey,
     rent_collector_account: &Pubkey,
     account_guid_hash: &BalanceAccountGuidHash,
-    dapp: DAppBookEntry,
+    params_hash: &Hash,
     instructions: &Vec<Instruction>,
 ) -> Instruction {
     let data = ProgramInstruction::FinalizeDAppTransaction {
         account_guid_hash: *account_guid_hash,
-        dapp,
-        instructions: instructions.clone(),
+        params_hash: *params_hash,
     }
     .borrow()
     .pack();

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -404,11 +404,7 @@ pub async fn init_update_signer(
             ),
         ],
         Some(&context.payer.pubkey()),
-        &[
-            &context.payer,
-            &multisig_op_account,
-            &initiator_account,
-        ],
+        &[&context.payer, &multisig_op_account, &initiator_account],
         context.recent_blockhash,
     );
     context
@@ -427,21 +423,14 @@ pub async fn update_signer(
     expected_signers: Option<Signers>,
     expected_error: Option<InstructionError>,
 ) {
-    let init_multisig_op_result = init_update_signer(
-        context,
-        approvers[0],
-        slot_update_type,
-        slot_id,
-        signer
-    ).await;
+    let init_multisig_op_result =
+        init_update_signer(context, approvers[0], slot_update_type, slot_id, signer).await;
 
     let multisig_op_account = match expected_error {
         None => init_multisig_op_result.unwrap(),
         Some(error) => {
             assert_eq!(
-                init_multisig_op_result
-                    .unwrap_err()
-                    .unwrap(),
+                init_multisig_op_result.unwrap_err().unwrap(),
                 TransactionError::InstructionError(1, error),
             );
             return;
@@ -498,7 +487,7 @@ pub async fn update_signer(
         &context.payer,
         context.recent_blockhash,
         ApprovalDisposition::APPROVE,
-        OperationDisposition::APPROVED
+        OperationDisposition::APPROVED,
     )
     .await;
 
@@ -601,11 +590,7 @@ pub async fn account_settings_update(
             ),
         ],
         Some(&context.payer.pubkey()),
-        &[
-            &context.payer,
-            &multisig_op_account,
-            &context.approvers[0],
-        ],
+        &[&context.payer, &multisig_op_account, &context.approvers[0]],
         context.recent_blockhash,
     );
     match expected_error {
@@ -678,7 +663,7 @@ pub async fn account_settings_update(
         &context.payer,
         context.recent_blockhash,
         ApprovalDisposition::APPROVE,
-        OperationDisposition::APPROVED
+        OperationDisposition::APPROVED,
     )
     .await;
 
@@ -1012,7 +997,7 @@ pub async fn init_balance_account_creation(
     context: &mut WalletTestContext,
     initiator_account: &Keypair,
     balance_account_guid_hash: BalanceAccountGuidHash,
-    creation_params: BalanceAccountCreation
+    creation_params: BalanceAccountCreation,
 ) -> Result<Pubkey, TransportError> {
     let rent = context.banks_client.get_rent().await.unwrap();
     let multisig_op_rent = rent.minimum_balance(MultisigOp::LEN);
@@ -1041,7 +1026,7 @@ pub async fn init_balance_account_creation(
                 creation_params.transfer_approvers.clone(),
                 creation_params.whitelist_enabled,
                 creation_params.dapps_enabled,
-                creation_params.address_book_slot_id
+                creation_params.address_book_slot_id,
             ),
         ],
         Some(&context.payer.pubkey()),
@@ -1049,7 +1034,8 @@ pub async fn init_balance_account_creation(
         context.recent_blockhash,
     );
 
-    context.banks_client
+    context
+        .banks_client
         .process_transaction(init_transaction)
         .await
         .map(|_| multisig_op_pubkey)
@@ -1378,7 +1364,7 @@ pub async fn setup_balance_account_tests_and_finalize(
         &context.payer,
         context.recent_blockhash,
         ApprovalDisposition::APPROVE,
-        OperationDisposition::APPROVED
+        OperationDisposition::APPROVED,
     )
     .await;
 
@@ -1480,11 +1466,7 @@ pub async fn setup_transfer_test(
                 ),
             ],
             Some(&context.payer.pubkey()),
-            &[
-                &context.payer,
-                &multisig_op_account,
-                &initiator_account,
-            ],
+            &[&context.payer, &multisig_op_account, &initiator_account],
             context.recent_blockhash,
         ))
         .await;
@@ -1545,14 +1527,9 @@ pub async fn init_address_book_update(
                 update.remove_address_book_entries,
                 update.balance_account_whitelist_updates,
             ),
-
         ],
         Some(&context.payer.pubkey()),
-        &[
-            &context.payer,
-            &multisig_op_account,
-            &initiator_account,
-        ],
+        &[&context.payer, &multisig_op_account, &initiator_account],
         context.recent_blockhash,
     );
 
@@ -1572,7 +1549,8 @@ pub async fn modify_address_book_and_whitelist(
     expected_error: Option<InstructionError>,
 ) {
     // add a whitelisted destination
-    let initiator_account = Keypair::from_base58_string(&context.initiator_account.to_base58_string());
+    let initiator_account =
+        Keypair::from_base58_string(&context.initiator_account.to_base58_string());
 
     let update = AddressBookUpdate {
         add_address_book_entries: entries_to_add.clone(),
@@ -1584,19 +1562,13 @@ pub async fn modify_address_book_and_whitelist(
         }],
     };
 
-    let init_result = init_address_book_update(
-        context,
-        &initiator_account,
-        update.clone()
-    ).await;
+    let init_result = init_address_book_update(context, &initiator_account, update.clone()).await;
 
     let multisig_op_account = match expected_error {
         None => init_result.unwrap(),
         Some(error) => {
             assert_eq!(
-                init_result
-                    .unwrap_err()
-                    .unwrap(),
+                init_result.unwrap_err().unwrap(),
                 TransactionError::InstructionError(1, error),
             );
             return;
@@ -1611,7 +1583,7 @@ pub async fn modify_address_book_and_whitelist(
         &context.payer,
         context.recent_blockhash,
         ApprovalDisposition::APPROVE,
-        OperationDisposition::APPROVED
+        OperationDisposition::APPROVED,
     )
     .await;
 
@@ -1664,11 +1636,7 @@ pub async fn init_balance_account_name_hash_update(
             ),
         ],
         Some(&context.payer.pubkey()),
-        &[
-            &context.payer,
-            &multisig_op_account,
-            &initiator_account,
-        ],
+        &[&context.payer, &multisig_op_account, &initiator_account],
         context.recent_blockhash,
     );
 
@@ -1684,21 +1652,17 @@ pub async fn update_balance_account_name_hash(
     account_name_hash: BalanceAccountNameHash,
     expected_error: Option<InstructionError>,
 ) -> Option<Pubkey> {
-    let initiator_account = Keypair::from_base58_string(&context.initiator_account.to_base58_string());
+    let initiator_account =
+        Keypair::from_base58_string(&context.initiator_account.to_base58_string());
 
-    let init_result = init_balance_account_name_hash_update(
-        context,
-        &initiator_account,
-        account_name_hash,
-    ).await;
+    let init_result =
+        init_balance_account_name_hash_update(context, &initiator_account, account_name_hash).await;
 
     let multisig_op_account = match expected_error {
         None => init_result.unwrap(),
         Some(error) => {
             assert_eq!(
-                init_result
-                    .unwrap_err()
-                    .unwrap(),
+                init_result.unwrap_err().unwrap(),
                 TransactionError::InstructionError(1, error),
             );
             return None;
@@ -1769,11 +1733,7 @@ pub async fn init_balance_account_policy_update(
             ),
         ],
         Some(&context.payer.pubkey()),
-        &[
-            &context.payer,
-            &multisig_op_account,
-            &initiator_account,
-        ],
+        &[&context.payer, &multisig_op_account, &initiator_account],
         context.recent_blockhash,
     );
 
@@ -1789,21 +1749,17 @@ pub async fn update_balance_account_policy(
     update: BalanceAccountPolicyUpdate,
     expected_error: Option<InstructionError>,
 ) -> Option<Pubkey> {
-    let initiator_account = Keypair::from_base58_string(&context.initiator_account.to_base58_string());
+    let initiator_account =
+        Keypair::from_base58_string(&context.initiator_account.to_base58_string());
 
-    let init_result = init_balance_account_policy_update(
-        context,
-        &initiator_account,
-        update.clone()
-    ).await;
+    let init_result =
+        init_balance_account_policy_update(context, &initiator_account, update.clone()).await;
 
     let multisig_op_account = match expected_error {
         None => init_result.unwrap(),
         Some(error) => {
             assert_eq!(
-                init_result
-                    .unwrap_err()
-                    .unwrap(),
+                init_result.unwrap_err().unwrap(),
                 TransactionError::InstructionError(1, error),
             );
             return None;

--- a/tests/dapp_book_update_tests.rs
+++ b/tests/dapp_book_update_tests.rs
@@ -18,7 +18,7 @@ use strike_wallet::utils::{SlotId, Slots};
 #[tokio::test]
 async fn test_dapp_book_update() {
     let started_at = SystemTime::now();
-    let mut context = setup_test(30_000).await;
+    let mut context = setup_test(40_000).await;
 
     let wallet_account = Keypair::new();
     let assistant_account = Keypair::new();

--- a/tests/dapp_book_update_tests.rs
+++ b/tests/dapp_book_update_tests.rs
@@ -24,7 +24,10 @@ async fn test_dapp_book_update() {
     let assistant_account = Keypair::new();
 
     let approvers = vec![Keypair::new(), Keypair::new()];
-    let signers = vec![approvers[0].pubkey_as_signer(), approvers[1].pubkey_as_signer()];
+    let signers = vec![
+        approvers[0].pubkey_as_signer(),
+        approvers[1].pubkey_as_signer(),
+    ];
 
     utils::init_wallet(
         &mut context.banks_client,
@@ -180,34 +183,29 @@ async fn test_dapp_book_update_initiator_approval() {
                 (SlotId::new(1), signers[1]),
                 (SlotId::new(2), signers[2]),
             ],
-            config_approvers: vec![
-                (SlotId::new(0), signers[0]),
-                (SlotId::new(1), signers[1]),
-            ],
+            config_approvers: vec![(SlotId::new(0), signers[0]), (SlotId::new(1), signers[1])],
         },
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     let multisig_op_account = utils::init_dapp_book_update(
         &mut context,
         wallet_account.pubkey(),
         &approvers[2],
         DAppBookUpdate {
-            add_dapps: vec![
-                (
-                    SlotId::new(0),
-                    DAppBookEntry {
-                        address: Keypair::new().pubkey(),
-                        name_hash: DAppBookEntryNameHash::new(&hash_of(b"DApp Name")),
-                    },
-                )
-            ],
+            add_dapps: vec![(
+                SlotId::new(0),
+                DAppBookEntry {
+                    address: Keypair::new().pubkey(),
+                    name_hash: DAppBookEntryNameHash::new(&hash_of(b"DApp Name")),
+                },
+            )],
             remove_dapps: vec![],
-        }
+        },
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     assert_multisig_op_dispositions(
         &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,
@@ -220,7 +218,7 @@ async fn test_dapp_book_update_initiator_approval() {
             ApprovalDispositionRecord {
                 approver: approvers[1].pubkey(),
                 disposition: ApprovalDisposition::NONE,
-            }
+            },
         ],
         OperationDisposition::NONE,
     );
@@ -230,20 +228,18 @@ async fn test_dapp_book_update_initiator_approval() {
         wallet_account.pubkey(),
         &approvers[0],
         DAppBookUpdate {
-            add_dapps: vec![
-                (
-                    SlotId::new(0),
-                    DAppBookEntry {
-                        address: Keypair::new().pubkey(),
-                        name_hash: DAppBookEntryNameHash::new(&hash_of(b"DApp Name")),
-                    },
-                )
-            ],
+            add_dapps: vec![(
+                SlotId::new(0),
+                DAppBookEntry {
+                    address: Keypair::new().pubkey(),
+                    name_hash: DAppBookEntryNameHash::new(&hash_of(b"DApp Name")),
+                },
+            )],
             remove_dapps: vec![],
-        }
+        },
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     assert_multisig_op_dispositions(
         &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,
@@ -256,7 +252,7 @@ async fn test_dapp_book_update_initiator_approval() {
             ApprovalDispositionRecord {
                 approver: approvers[1].pubkey(),
                 disposition: ApprovalDisposition::NONE,
-            }
+            },
         ],
         OperationDisposition::NONE,
     );

--- a/tests/init_wallet_tests.rs
+++ b/tests/init_wallet_tests.rs
@@ -88,7 +88,7 @@ async fn init_wallet() {
 async fn invalid_wallet_initialization() {
     let program_id = Keypair::new().pubkey();
     let mut pt = ProgramTest::new("strike_wallet", program_id, processor!(Processor::process));
-    pt.set_bpf_compute_max_units(30_000);
+    pt.set_bpf_compute_max_units(40_000);
     let (mut banks_client, payer, recent_blockhash) = pt.start().await;
     let wallet_account = Keypair::new();
     let assistant_account = Keypair::new();

--- a/tests/wallet_config_policy_update_tests.rs
+++ b/tests/wallet_config_policy_update_tests.rs
@@ -22,7 +22,7 @@ use strike_wallet::utils::SlotId;
 #[tokio::test]
 async fn wallet_config_policy_update() {
     let started_at = SystemTime::now();
-    let mut context = setup_test(30_000).await;
+    let mut context = setup_test(40_000).await;
 
     let wallet_account = Keypair::new();
     let assistant_account = Keypair::new();
@@ -174,7 +174,7 @@ async fn wallet_config_policy_update() {
 
 #[tokio::test]
 async fn only_one_pending_wallet_config_policy_update_allowed_at_time() {
-    let mut context = setup_test(30_000).await;
+    let mut context = setup_test(40_000).await;
 
     let wallet_account = Keypair::new();
     let assistant_account = Keypair::new();
@@ -309,7 +309,7 @@ async fn only_one_pending_wallet_config_policy_update_allowed_at_time() {
 
 #[tokio::test]
 async fn invalid_wallet_config_policy_updates() {
-    let mut context = setup_test(30_000).await;
+    let mut context = setup_test(40_000).await;
 
     let wallet_account = Keypair::new();
     let assistant_account = Keypair::new();

--- a/tests/wallet_config_policy_update_tests.rs
+++ b/tests/wallet_config_policy_update_tests.rs
@@ -442,8 +442,8 @@ async fn wallet_config_policy_update_initiator_approval() {
             config_approvers: vec![(SlotId::new(0), signers[0]), (SlotId::new(1), signers[1])],
         },
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     let update = WalletConfigPolicyUpdate {
         approvals_required_for_config: Some(1),
@@ -458,8 +458,8 @@ async fn wallet_config_policy_update_initiator_approval() {
         &approvers[0],
         &update.clone(),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     assert_multisig_op_dispositions(
         &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,
@@ -482,7 +482,7 @@ async fn wallet_config_policy_update_initiator_approval() {
         &multisig_op_account,
         vec![&approvers[0], &approvers[1]],
     )
-        .await;
+    .await;
 
     utils::finalize_wallet_config_policy_update(
         &mut context,
@@ -490,7 +490,7 @@ async fn wallet_config_policy_update_initiator_approval() {
         multisig_op_account,
         &update.clone(),
     )
-        .await;
+    .await;
 
     let multisig_op_account = utils::init_wallet_config_policy_update(
         &mut context,
@@ -501,20 +501,18 @@ async fn wallet_config_policy_update_initiator_approval() {
             approval_timeout_for_config: Some(Duration::from_secs(7200)),
             add_config_approvers: vec![],
             remove_config_approvers: vec![],
-        }
+        },
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     assert_multisig_op_dispositions(
         &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,
         1,
-        &vec![
-            ApprovalDispositionRecord {
-                approver: approvers[0].pubkey(),
-                disposition: ApprovalDisposition::APPROVE,
-            },
-        ],
+        &vec![ApprovalDispositionRecord {
+            approver: approvers[0].pubkey(),
+            disposition: ApprovalDisposition::APPROVE,
+        }],
         OperationDisposition::APPROVED,
     );
 }

--- a/tests/wallet_update_signers_tests.rs
+++ b/tests/wallet_update_signers_tests.rs
@@ -6,7 +6,7 @@ pub use common::instructions::*;
 pub use common::utils::*;
 
 use std::borrow::BorrowMut;
-use std::time::{Duration};
+use std::time::Duration;
 
 use solana_program::instruction::InstructionError::Custom;
 
@@ -14,7 +14,9 @@ use crate::common::utils;
 use common::instructions;
 use strike_wallet::error::WalletError;
 use strike_wallet::instruction::InitialWalletConfig;
-use strike_wallet::model::multisig_op::{ApprovalDisposition, ApprovalDispositionRecord, OperationDisposition, SlotUpdateType};
+use strike_wallet::model::multisig_op::{
+    ApprovalDisposition, ApprovalDispositionRecord, OperationDisposition, SlotUpdateType,
+};
 use strike_wallet::model::wallet::Signers;
 use strike_wallet::utils::SlotId;
 use {
@@ -52,7 +54,7 @@ async fn test_add_and_remove_signer() {
 
     let signer_to_add_and_remove = approvers[2].pubkey_as_signer();
 
-    let mut context = setup_wallet_test(30_000, initial_config).await;
+    let mut context = setup_wallet_test(40_000, initial_config).await;
 
     update_signer(
         context.borrow_mut(),
@@ -97,7 +99,7 @@ async fn test_add_and_remove_signer_init_failures() {
     let signer1 = approvers[1].pubkey_as_signer();
     let signer2 = approvers[2].pubkey_as_signer();
 
-    let mut context = setup_wallet_test(30_000, initial_config).await;
+    let mut context = setup_wallet_test(40_000, initial_config).await;
 
     // put a signer in a slot already filled
     update_signer(
@@ -148,7 +150,7 @@ async fn test_remove_signer_fails_for_a_transfer_approver() {
         &context.payer,
         context.recent_blockhash,
         ApprovalDisposition::APPROVE,
-        OperationDisposition::APPROVED
+        OperationDisposition::APPROVED,
     )
     .await;
     utils::finalize_balance_account_creation(context.borrow_mut()).await;
@@ -179,18 +181,22 @@ async fn test_remove_signer_fails_for_a_transfer_approver() {
 async fn test_signers_update_initiator_approval() {
     let approvers = vec![Keypair::new(), Keypair::new(), Keypair::new()];
 
-    let mut context = setup_wallet_test(30_000, InitialWalletConfig {
-        approvals_required_for_config: 2,
-        approval_timeout_for_config: Duration::from_secs(3600),
-        signers: vec![
-            (SlotId::new(0), approvers[0].pubkey_as_signer()),
-            (SlotId::new(1), approvers[1].pubkey_as_signer()),
-        ],
-        config_approvers: vec![
-            (SlotId::new(0), approvers[0].pubkey_as_signer()),
-            (SlotId::new(1), approvers[1].pubkey_as_signer()),
-        ],
-    }).await;
+    let mut context = setup_wallet_test(
+        30_000,
+        InitialWalletConfig {
+            approvals_required_for_config: 2,
+            approval_timeout_for_config: Duration::from_secs(3600),
+            signers: vec![
+                (SlotId::new(0), approvers[0].pubkey_as_signer()),
+                (SlotId::new(1), approvers[1].pubkey_as_signer()),
+            ],
+            config_approvers: vec![
+                (SlotId::new(0), approvers[0].pubkey_as_signer()),
+                (SlotId::new(1), approvers[1].pubkey_as_signer()),
+            ],
+        },
+    )
+    .await;
 
     let signer_to_add_and_remove = approvers[2].pubkey_as_signer();
     let multisig_op_account = utils::init_update_signer(
@@ -200,8 +206,8 @@ async fn test_signers_update_initiator_approval() {
         2,
         signer_to_add_and_remove,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     assert_multisig_op_dispositions(
         &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,
@@ -219,18 +225,22 @@ async fn test_signers_update_initiator_approval() {
         OperationDisposition::NONE,
     );
 
-    let mut context = setup_wallet_test(30_000, InitialWalletConfig {
-        approvals_required_for_config: 1,
-        approval_timeout_for_config: Duration::from_secs(3600),
-        signers: vec![
-            (SlotId::new(0), approvers[0].pubkey_as_signer()),
-            (SlotId::new(1), approvers[1].pubkey_as_signer()),
-        ],
-        config_approvers: vec![
-            (SlotId::new(0), approvers[0].pubkey_as_signer()),
-            (SlotId::new(1), approvers[1].pubkey_as_signer()),
-        ],
-    }).await;
+    let mut context = setup_wallet_test(
+        30_000,
+        InitialWalletConfig {
+            approvals_required_for_config: 1,
+            approval_timeout_for_config: Duration::from_secs(3600),
+            signers: vec![
+                (SlotId::new(0), approvers[0].pubkey_as_signer()),
+                (SlotId::new(1), approvers[1].pubkey_as_signer()),
+            ],
+            config_approvers: vec![
+                (SlotId::new(0), approvers[0].pubkey_as_signer()),
+                (SlotId::new(1), approvers[1].pubkey_as_signer()),
+            ],
+        },
+    )
+    .await;
 
     let signer_to_add_and_remove = approvers[2].pubkey_as_signer();
     let multisig_op_account = utils::init_update_signer(
@@ -240,8 +250,8 @@ async fn test_signers_update_initiator_approval() {
         2,
         signer_to_add_and_remove,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     assert_multisig_op_dispositions(
         &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,


### PR DESCRIPTION
## Description
Remove the compression when sending dapp transactions in. Also increased the default compute budget from 30,000 to 40,000 as I've been seeing some sporadic failures due to exceeding the budget.

## Motivation and Context
It adds complexity which, now that dapp transaction instructions can be supplied over multiple transactions,
doesn't seem necessary.

## How Has This Been Tested?
All existing unit tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

