### PR TITLE
limit wallet data to 10K

### DIFF
--- a/src/model/wallet.rs
+++ b/src/model/wallet.rs
@@ -51,10 +51,10 @@ impl IsInitialized for Wallet {
 impl Wallet {
     pub const MAX_BALANCE_ACCOUNTS: usize = 10;
     pub const MAX_SIGNERS: usize = 24;
-    pub const MAX_ADDRESS_BOOK_ENTRIES: usize = 128;
+    pub const MAX_ADDRESS_BOOK_ENTRIES: usize = 96;
     pub const MIN_APPROVAL_TIMEOUT: Duration = Duration::from_secs(60);
     pub const MAX_APPROVAL_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24 * 365);
-    pub const MAX_DAPP_BOOK_ENTRIES: usize = 32;
+    pub const MAX_DAPP_BOOK_ENTRIES: usize = 20;
 
     pub fn get_signers_keys(&self) -> Vec<Pubkey> {
         return self
@@ -804,5 +804,17 @@ impl Pack for Wallet {
             },
             dapp_book: DAppBook::unpack_from_slice(dapp_book_src)?,
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::model::wallet::Wallet;
+    use solana_program::program_pack::Pack;
+
+    #[test]
+    fn test_wallet_data_size() {
+        // plan is to convert wallet account to PDA, which has a data limit of 10K
+        assert!(Wallet::LEN < 10 * 1024)
     }
 }

--- a/src/model/wallet.rs
+++ b/src/model/wallet.rs
@@ -49,9 +49,9 @@ impl IsInitialized for Wallet {
 }
 
 impl Wallet {
-    pub const MAX_BALANCE_ACCOUNTS: usize = 10;
+    pub const MAX_BALANCE_ACCOUNTS: usize = 9;
     pub const MAX_SIGNERS: usize = 24;
-    pub const MAX_ADDRESS_BOOK_ENTRIES: usize = 96;
+    pub const MAX_ADDRESS_BOOK_ENTRIES: usize = 88;
     pub const MIN_APPROVAL_TIMEOUT: Duration = Duration::from_secs(60);
     pub const MAX_APPROVAL_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24 * 365);
     pub const MAX_DAPP_BOOK_ENTRIES: usize = 20;


### PR DESCRIPTION
## Description
Reduce the number of address book and dapp book slots to bring us under 10K in data, while also making room for adding a second key to each signer slot

## Motivation and Context
Will make it easier to convert account to a PDA.

## How Has This Been Tested?
Existing tests pass, added a simple test to ensure that the size stays under 10K

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

