### PR TITLE
add version to program and multisig ops

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod model;
 pub mod processor;
 pub mod serialization_utils;
 pub mod utils;
+pub mod version;
 
 mod entrypoint;
 mod handlers;

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,1 @@
+pub static VERSION: u32 = 1;

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -40,6 +40,7 @@ use strike_wallet::model::multisig_op::{
 use strike_wallet::model::signer::Signer;
 use strike_wallet::model::wallet::Signers;
 use strike_wallet::utils::SlotId;
+use strike_wallet::version::VERSION;
 use uuid::Uuid;
 use {
     solana_program::{program_pack::Pack, pubkey::Pubkey},
@@ -1171,6 +1172,7 @@ pub async fn setup_balance_account_tests(
         ])
     );
     assert_eq!(multisig_op.dispositions_required, 2);
+    assert_eq!(multisig_op.version, VERSION);
 
     let expected_creation_params = BalanceAccountCreation {
         slot_id: SlotId::new(0),


### PR DESCRIPTION
## Description
Adds a VERSION to the program, and store it in the multisig op.

## Motivation and Context
For safety, when we upgrade the wallet program, any pending multisig ops will not be processed (approvals will fail, and finalization will close without executing the op). So we need to store the version of the program which each multisig op is created with.

## How Has This Been Tested?
All existing tests pass, added a check that the multisig op version is as expected to `setup_balance_account_tests`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

