### PR TITLE
fail multisig ops with wrong version

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -118,6 +118,9 @@ pub enum WalletError {
     /// Invalid PDA address or bump seed
     #[error("Invalid PDA")]
     InvalidPDA,
+    /// The operation was initiated by a different version of the program
+    #[error("Operation Version Mismatch")]
+    OperationVersionMismatch,
 }
 
 impl From<WalletError> for ProgramError {

--- a/src/handlers/approval_disposition_handler.rs
+++ b/src/handlers/approval_disposition_handler.rs
@@ -1,6 +1,7 @@
 use crate::error::WalletError;
 use crate::handlers::utils::{get_clock_from_next_account, next_program_account_info};
 use crate::model::multisig_op::{ApprovalDisposition, MultisigOp};
+use crate::version::{Versioned, VERSION};
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
 use solana_program::hash::Hash;
@@ -17,6 +18,10 @@ pub fn handle(
     let multisig_op_account_info = next_program_account_info(accounts_iter, program_id)?;
     let signer_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    if MultisigOp::version_from_slice(&multisig_op_account_info.data.borrow())? != VERSION {
+        return Err(WalletError::OperationVersionMismatch.into());
+    }
 
     let mut multisig_op = MultisigOp::unpack(&multisig_op_account_info.data.borrow())?;
 

--- a/src/handlers/dapp_transaction_handler.rs
+++ b/src/handlers/dapp_transaction_handler.rs
@@ -1,4 +1,14 @@
 use bitvec::macros::internal::funty::Fundamental;
+use solana_program::account_info::{next_account_info, AccountInfo};
+use solana_program::entrypoint::ProgramResult;
+use solana_program::hash::Hash;
+use solana_program::instruction::Instruction;
+use solana_program::msg;
+use solana_program::program::invoke_signed;
+use solana_program::program_error::ProgramError;
+use solana_program::program_pack::Pack;
+use solana_program::pubkey::Pubkey;
+use spl_token::state::Account as SPLAccount;
 
 use crate::error::WalletError;
 use crate::handlers::utils::{
@@ -10,16 +20,7 @@ use crate::model::balance_account::BalanceAccountGuidHash;
 use crate::model::dapp_multisig_data::DAppMultisigData;
 use crate::model::multisig_op::{ApprovalDisposition, MultisigOp, OperationDisposition};
 use crate::model::wallet::Wallet;
-use solana_program::account_info::{next_account_info, AccountInfo};
-use solana_program::entrypoint::ProgramResult;
-use solana_program::hash::Hash;
-use solana_program::instruction::Instruction;
-use solana_program::msg;
-use solana_program::program::invoke_signed;
-use solana_program::program_error::ProgramError;
-use solana_program::program_pack::Pack;
-use solana_program::pubkey::Pubkey;
-use spl_token::state::Account as SPLAccount;
+use crate::version::{Versioned, VERSION};
 
 pub fn init(
     program_id: &Pubkey,
@@ -94,6 +95,11 @@ pub fn supply_instructions(
     if !initiator_account_info.is_signer {
         return Err(ProgramError::MissingRequiredSignature);
     }
+
+    if MultisigOp::version_from_slice(&multisig_op_account_info.data.borrow())? != VERSION {
+        return Err(WalletError::OperationVersionMismatch.into());
+    }
+
     // TODO - once we are storing the initiator in the multisig op (PRIME-3999), verify that the supplied one matches
 
     let params_hash = {
@@ -252,60 +258,80 @@ pub fn finalize(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    let multisig_op = MultisigOp::unpack(&multisig_op_account_info.data.borrow())?;
-    let multisig_data = DAppMultisigData::unpack(&multisig_data_account_info.data.borrow())?;
+    if MultisigOp::version_from_slice(&multisig_op_account_info.data.borrow())? == VERSION {
+        let multisig_op = MultisigOp::unpack(&multisig_op_account_info.data.borrow())?;
+        let multisig_data = DAppMultisigData::unpack(&multisig_data_account_info.data.borrow())?;
 
-    let instructions = multisig_data.instructions()?;
-    let (is_approved, is_final) = {
-        const NOT_FINAL: u32 = WalletError::TransferDispositionNotFinal as u32;
-        match multisig_op.approved(multisig_data.hash()?, &clock, Some(params_hash)) {
-            Ok(a) => (a, true),
-            Err(ProgramError::Custom(NOT_FINAL)) => (false, false),
-            Err(e) => return Err(e),
+        let instructions = multisig_data.instructions()?;
+        let (is_approved, is_final) = {
+            const NOT_FINAL: u32 = WalletError::TransferDispositionNotFinal as u32;
+            match multisig_op.approved(multisig_data.hash()?, &clock, Some(params_hash)) {
+                Ok(a) => (a, true),
+                Err(ProgramError::Custom(NOT_FINAL)) => (false, false),
+                Err(e) => return Err(e),
+            }
+        };
+
+        let bump_seed =
+            validate_balance_account_and_get_seed(balance_account, account_guid_hash, program_id)?;
+
+        let starting_balances: Vec<u64> = if is_final {
+            Vec::new()
+        } else {
+            account_balances(accounts)
+        };
+
+        let starting_spl_balances: Vec<SplBalance> = if is_final {
+            Vec::new()
+        } else {
+            spl_balances(accounts)
+        };
+
+        // actually run instructions if action is approved or this is a simulation (we are not final)
+        if is_approved || !is_final {
+            for instruction in instructions.iter() {
+                invoke_signed(
+                    &instruction,
+                    &accounts,
+                    &[&[&account_guid_hash.to_bytes(), &[bump_seed]]],
+                )?;
+            }
         }
-    };
 
-    let bump_seed =
-        validate_balance_account_and_get_seed(balance_account, account_guid_hash, program_id)?;
-
-    let starting_balances: Vec<u64> = if is_final {
-        Vec::new()
-    } else {
-        account_balances(accounts)
-    };
-
-    let starting_spl_balances: Vec<SplBalance> = if is_final {
-        Vec::new()
-    } else {
-        spl_balances(accounts)
-    };
-
-    // actually run instructions if action is approved or this is a simulation (we are not final)
-    if is_approved || !is_final {
-        for instruction in instructions.iter() {
-            invoke_signed(
-                &instruction,
-                &accounts,
-                &[&[&account_guid_hash.to_bytes(), &[bump_seed]]],
-            )?;
+        if is_final {
+            cleanup(
+                &multisig_op_account_info,
+                &multisig_data_account_info,
+                &rent_collector_account_info,
+            )
+        } else {
+            msg!(&balance_changes_from_simulation(
+                starting_balances,
+                starting_spl_balances,
+                account_balances(accounts),
+                spl_balances(accounts),
+                accounts,
+            ));
+            Err(WalletError::SimulationFinished.into())
         }
-    }
-
-    if is_final {
-        collect_remaining_balance(&multisig_op_account_info, &rent_collector_account_info)?;
-        collect_remaining_balance(&multisig_data_account_info, &rent_collector_account_info)?;
-
-        Ok(())
     } else {
-        msg!(&balance_changes_from_simulation(
-            starting_balances,
-            starting_spl_balances,
-            account_balances(accounts),
-            spl_balances(accounts),
-            accounts,
-        ));
-        Err(WalletError::SimulationFinished.into())
+        cleanup(
+            &multisig_op_account_info,
+            &multisig_data_account_info,
+            &rent_collector_account_info,
+        )
     }
+}
+
+fn cleanup(
+    multisig_op_account_info: &AccountInfo,
+    multisig_data_account_info: &AccountInfo,
+    rent_collector_account_info: &AccountInfo,
+) -> ProgramResult {
+    collect_remaining_balance(multisig_op_account_info, rent_collector_account_info)?;
+    collect_remaining_balance(multisig_data_account_info, rent_collector_account_info)?;
+
+    Ok(())
 }
 
 struct SplBalance {

--- a/src/handlers/dapp_transaction_handler.rs
+++ b/src/handlers/dapp_transaction_handler.rs
@@ -12,7 +12,7 @@ use spl_token::state::Account as SPLAccount;
 
 use crate::error::WalletError;
 use crate::handlers::utils::{
-    calculate_expires, collect_remaining_balance, get_clock_from_next_account,
+    calculate_expires, collect_remaining_balance, get_clock_from_next_account, log_op_disposition,
     next_program_account_info, validate_balance_account_and_get_seed,
 };
 use crate::model::address_book::DAppBookEntry;
@@ -315,6 +315,7 @@ pub fn finalize(
             Err(WalletError::SimulationFinished.into())
         }
     } else {
+        log_op_disposition(OperationDisposition::EXPIRED);
         cleanup(
             &multisig_op_account_info,
             &multisig_data_account_info,

--- a/src/handlers/utils.rs
+++ b/src/handlers/utils.rs
@@ -1,6 +1,8 @@
 use crate::error::WalletError;
 use crate::model::balance_account::{BalanceAccount, BalanceAccountGuidHash};
-use crate::model::multisig_op::{ApprovalDisposition, MultisigOp, MultisigOpParams};
+use crate::model::multisig_op::{
+    ApprovalDisposition, MultisigOp, MultisigOpParams, OperationDisposition,
+};
 use crate::model::wallet::Wallet;
 use crate::version::{Versioned, VERSION};
 use solana_program::{
@@ -123,6 +125,10 @@ pub fn start_multisig_config_op(
     Ok(())
 }
 
+pub fn log_op_disposition(disposition: OperationDisposition) {
+    msg!("OperationDisposition: [{}]", disposition.to_u8());
+}
+
 pub fn finalize_multisig_op<F>(
     multisig_op_account_info: &AccountInfo,
     account_to_return_rent_to: &AccountInfo,
@@ -143,6 +149,8 @@ where
         if multisig_op.approved(expected_params.hash(), &clock, None)? {
             on_op_approved()?
         }
+    } else {
+        log_op_disposition(OperationDisposition::EXPIRED);
     }
 
     collect_remaining_balance(&multisig_op_account_info, &account_to_return_rent_to)?;

--- a/src/handlers/utils.rs
+++ b/src/handlers/utils.rs
@@ -2,6 +2,7 @@ use crate::error::WalletError;
 use crate::model::balance_account::{BalanceAccount, BalanceAccountGuidHash};
 use crate::model::multisig_op::{ApprovalDisposition, MultisigOp, MultisigOpParams};
 use crate::model::wallet::Wallet;
+use crate::version::{Versioned, VERSION};
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     clock::Clock,
@@ -136,10 +137,12 @@ where
         return Err(ProgramError::MissingRequiredSignature);
     }
 
-    let multisig_op = MultisigOp::unpack(&multisig_op_account_info.data.borrow())?;
+    if MultisigOp::version_from_slice(&multisig_op_account_info.data.borrow())? == VERSION {
+        let multisig_op = MultisigOp::unpack(&multisig_op_account_info.data.borrow())?;
 
-    if multisig_op.approved(expected_params.hash(), &clock, None)? {
-        on_op_approved()?
+        if multisig_op.approved(expected_params.hash(), &clock, None)? {
+            on_op_approved()?
+        }
     }
 
     collect_remaining_balance(&multisig_op_account_info, &account_to_return_rent_to)?;

--- a/src/model/multisig_op.rs
+++ b/src/model/multisig_op.rs
@@ -10,7 +10,7 @@ use crate::model::signer::Signer;
 use crate::model::wallet::Wallet;
 use crate::serialization_utils::pack_option;
 use crate::utils::SlotId;
-use crate::version::VERSION;
+use crate::version::{Versioned, VERSION};
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
 use bitvec::macros::internal::funty::Fundamental;
 use bytes::BufMut;
@@ -394,6 +394,18 @@ impl MultisigOp {
         }
 
         Ok(false)
+    }
+}
+
+impl Versioned for MultisigOp {
+    fn version_from_slice(src: &[u8]) -> Result<u32, ProgramError> {
+        if src.len() < 5 {
+            Err(ProgramError::InvalidAccountData)
+        } else {
+            let mut buf: [u8; 4] = [0; 4];
+            buf.copy_from_slice(&src[1..=4]);
+            Ok(u32::from_le_bytes(buf))
+        }
     }
 }
 

--- a/src/model/multisig_op.rs
+++ b/src/model/multisig_op.rs
@@ -1,5 +1,6 @@
 use crate::constants::{HASH_LEN, PUBKEY_BYTES};
 use crate::error::WalletError;
+use crate::handlers::utils::log_op_disposition;
 use crate::instruction::{
     append_instruction, AddressBookUpdate, BalanceAccountCreation, BalanceAccountPolicyUpdate,
     DAppBookUpdate, WalletConfigPolicyUpdate,
@@ -387,7 +388,7 @@ impl MultisigOp {
         if clock.unix_timestamp > self.expires_at {
             operation_disposition = OperationDisposition::EXPIRED
         }
-        msg!("OperationDisposition: [{}]", operation_disposition.to_u8());
+        log_op_disposition(operation_disposition);
 
         if operation_disposition == OperationDisposition::APPROVED {
             return Ok(true);

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,1 +1,7 @@
+use solana_program::program_error::ProgramError;
+
 pub static VERSION: u32 = 1;
+
+pub trait Versioned {
+    fn version_from_slice(src: &[u8]) -> Result<u32, ProgramError>;
+}

--- a/tests/address_book_update_tests.rs
+++ b/tests/address_book_update_tests.rs
@@ -19,7 +19,11 @@ use strike_wallet::model::multisig_op::{
 async fn test_address_book_update() {
     let (mut context, _) = setup_balance_account_tests_and_finalize(Some(64000)).await;
 
-    let wallet = get_wallet(&mut context.banks_client, &context.wallet_account.pubkey()).await;
+    let wallet = get_wallet(
+        &mut context.pt_context.banks_client,
+        &context.wallet_account.pubkey(),
+    )
+    .await;
 
     let initial_entries = wallet.address_book.filled_slots().clone();
     verify_address_book(&mut context, initial_entries.clone(), vec![]).await;
@@ -113,7 +117,11 @@ async fn test_address_book_update() {
 async fn test_address_book_failures() {
     let (mut context, _) = setup_balance_account_tests_and_finalize(Some(32000)).await;
 
-    let wallet = get_wallet(&mut context.banks_client, &context.wallet_account.pubkey()).await;
+    let wallet = get_wallet(
+        &mut context.pt_context.banks_client,
+        &context.wallet_account.pubkey(),
+    )
+    .await;
 
     // whitelist both entries, but whitelisting not on
     modify_address_book_and_whitelist(
@@ -191,7 +199,11 @@ async fn test_address_book_update_initiator_approval() {
     let (mut context, _) = setup_balance_account_tests_and_finalize(Some(64000)).await;
     let initiator_account = Keypair::from_base58_string(&context.approvers[2].to_base58_string());
 
-    let wallet = get_wallet(&mut context.banks_client, &context.wallet_account.pubkey()).await;
+    let wallet = get_wallet(
+        &mut context.pt_context.banks_client,
+        &context.wallet_account.pubkey(),
+    )
+    .await;
 
     let multisig_op_account = init_address_book_update(
         &mut context,
@@ -206,7 +218,7 @@ async fn test_address_book_update_initiator_approval() {
     .unwrap();
 
     assert_multisig_op_dispositions(
-        &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,
+        &get_multisig_op_data(&mut context.pt_context.banks_client, multisig_op_account).await,
         2,
         &vec![
             ApprovalDispositionRecord {
@@ -235,7 +247,7 @@ async fn test_address_book_update_initiator_approval() {
     .unwrap();
 
     assert_multisig_op_dispositions(
-        &get_multisig_op_data(&mut context.banks_client, multisig_op_account).await,
+        &get_multisig_op_data(&mut context.pt_context.banks_client, multisig_op_account).await,
         2,
         &vec![
             ApprovalDispositionRecord {

--- a/tests/wallet_update_signers_tests.rs
+++ b/tests/wallet_update_signers_tests.rs
@@ -143,12 +143,12 @@ async fn test_remove_signer_fails_for_a_transfer_approver() {
     let mut context = setup_balance_account_tests(None, true).await;
 
     approve_or_deny_n_of_n_multisig_op(
-        context.banks_client.borrow_mut(),
+        context.pt_context.banks_client.borrow_mut(),
         &context.program_id,
         &context.multisig_op_account.pubkey(),
         vec![&context.approvers[0], &context.approvers[1]],
-        &context.payer,
-        context.recent_blockhash,
+        &context.pt_context.payer,
+        context.pt_context.last_blockhash,
         ApprovalDisposition::APPROVE,
         OperationDisposition::APPROVED,
     )
@@ -158,9 +158,9 @@ async fn test_remove_signer_fails_for_a_transfer_approver() {
     // approvers 0 & 1 are config and transfer approvers, 2 is just a transfer approver
     let multisig_op_account = Keypair::new();
     verify_multisig_op_init_fails(
-        &mut context.banks_client,
-        context.recent_blockhash,
-        &context.payer,
+        &mut context.pt_context.banks_client,
+        context.pt_context.last_blockhash,
+        &context.pt_context.payer,
         &context.assistant_account,
         &multisig_op_account,
         instructions::init_update_signer(


### PR DESCRIPTION
## Description
Approving/Denying or supplying dapp instructions for a multisig op from a different version of the program returns an error.
Finalizing a multisig op from a different version of the program closes the multisig op without performing the action.

To test this functionality, I used the `ProgramTestContext`'s `set_account` function to manipulate the version in the multisig op account data. `BalanceAccountTestContext` was previously pulling the `banks_client`, `payer`, and `last_blockhash` fields out from the `ProgramTestContext`, so, due to rust borrowing rules, I had to replace them with a `pt_context` field, which required changing a lot of test code.

## Motivation and Context
This change will ensure that any multisig ops started before an upgrade will be handled safely.

## How Has This Been Tested?
Unit tests for dapp transaction and balance account creation multisig ops where the version doesn't match the program (all other multisig ops share the same implementation as balance account creation). 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

