### PR TITLE
added make target to read version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ test:
 
 deploy_and_test: build deploy test
 
+version:
+	@grep 'static VERSION' ./src/version.rs | sed 's/pub static VERSION: u32 = \(.*\);/\1/'
+
 test-balance-account-update:
 	RUST_BACKTRACE=${rust-backtrace} cargo test-bpf --test=balance_account_update_tests
 


### PR DESCRIPTION
## Description
Added a make target that reads the version from `version.rs`

## Motivation and Context
So that CI can tag the build with the version identifier.

## How Has This Been Tested?
Ran `make version` manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

