### PR TITLE
wallet account to PDA; update to latest solana version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,35 +13,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.4.7"
+name = "aead"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+dependencies = [
+ "generic-array 0.14.5",
+]
 
 [[package]]
-name = "ahash"
-version = "0.6.3"
+name = "aes"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796540673305a66d127804eef19ad696f1f204b8c1025aaca4958c17eab32877"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "getrandom 0.2.3",
- "once_cell",
- "version_check 0.9.4",
+ "cfg-if 1.0.0",
+ "cipher 0.3.0",
+ "cpufeatures",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm-siv"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589c637f0e68c877bbd59a4599bbe849cac8e5f3e4b5a3ebae8f528cd218dcdc"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher 0.3.0",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -50,9 +60,9 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.5",
  "once_cell",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -81,15 +91,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
-
-[[package]]
-name = "arc-swap"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arc-swap"
@@ -105,9 +109,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ascii"
@@ -122,10 +126,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "async-stream"
-version = "0.3.2"
+name = "async-mutex"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -133,13 +146,13 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -149,8 +162,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -166,44 +179,22 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-
-[[package]]
-name = "autocfg"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backoff"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom 0.2.3",
+ "getrandom 0.2.5",
  "instant",
- "pin-project",
- "rand 0.8.4",
+ "pin-project-lite",
+ "rand 0.8.5",
  "tokio",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "serde",
 ]
 
 [[package]]
@@ -211,37 +202,6 @@ name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
-name = "base32"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
-
-[[package]]
-name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
@@ -254,6 +214,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64ct"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71acf5509fc522cce1b100ac0121c635129bfd4d91cdf036bcc9b9935f97ccf5"
 
 [[package]]
 name = "bincode"
@@ -277,7 +243,7 @@ dependencies = [
  "lazycell",
  "peeking_take_while",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
+ "quote 1.0.16",
  "regex",
  "rustc-hash",
  "shlex",
@@ -285,9 +251,18 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "bitvec"
@@ -303,17 +278,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "0.3.8"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "constant_time_eq",
- "crypto-mac 0.8.0",
- "digest 0.9.0",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -340,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array 0.14.5",
 ]
@@ -364,54 +338,48 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dda7dc709193c0d86a1a51050a926dc3df1cf262ec46a23a25dba421ea1924"
+checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684155372435f578c0fa1acd13ebbb182cc19d6b38b64ae7901da4393217d264"
+checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
 dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2 1.0.36",
- "syn 1.0.85",
+ "syn 1.0.89",
 ]
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2102f62f8b6d3edeab871830782285b64cc1830168094db05c8e458f209bc5c3"
+checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196c978c4c9b0b142d446ef3240690bf5a8a33497074a113ff9a337ccb750483"
+checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
-
-[[package]]
-name = "bs58"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 
 [[package]]
 name = "bs58"
@@ -452,9 +420,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439989e6b8c38d1b6570a384ef1e49c8848128f5a97f3914baef02920842712f"
+checksum = "0e851ca7c24871e7336801608a4797d7376545b6928a10d32d75685687141ead"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -466,8 +434,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e215f8c2f9f79cb53c8335e687ffd07d5bfcb6fe5fc80723762d0be46e7cc54"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -478,32 +446,15 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "either",
- "iovec",
-]
-
-[[package]]
-name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "bzip2"
-version = "0.3.3"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -533,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
@@ -571,7 +522,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
+ "time 0.1.43",
  "winapi 0.3.9",
 ]
 
@@ -585,14 +536,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.3.0"
+name = "cipher"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.7.2",
+ "libloading",
 ]
 
 [[package]]
@@ -611,15 +581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,38 +591,6 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
-]
-
-[[package]]
-name = "console"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0994e656bba7b922d8dd1245db90672ffb701e684e45be58f20719d69abc5a"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "terminal_size",
- "termios",
- "unicode-width",
- "winapi 0.3.9",
- "winapi-util",
-]
-
-[[package]]
-name = "console"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "terminal_size",
- "unicode-width",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -678,6 +607,32 @@ dependencies = [
  "unicode-width",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
+dependencies = [
+ "log",
+ "web-sys",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "const_fn"
@@ -699,9 +654,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -727,40 +682,30 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -771,17 +716,18 @@ checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
+ "autocfg",
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils",
  "lazy_static",
  "memoffset",
  "scopeguard",
@@ -789,20 +735,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -816,11 +751,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array 0.14.5",
+ "typenum",
 ]
 
 [[package]]
@@ -834,47 +770,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.9.1"
+name = "ctr"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
- "generic-array 0.14.5",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
-dependencies = [
- "generic-array 0.14.5",
- "subtle",
+ "cipher 0.3.0",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "2.1.3"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b85542f99a2dfa2a1b8e192662741c9859a846b296bef1c92ef9b58b5a216"
-dependencies = [
- "byteorder",
- "digest 0.8.1",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -891,13 +804,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivation-path"
-version = "0.1.3"
+name = "der"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193388a8c8c75a490b604ff61775e236541b8975e98e5ca1f6ea97d122b7e2db"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
- "failure",
+ "const-oid",
 ]
+
+[[package]]
+name = "derivation-path"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
 
 [[package]]
 name = "derive_more"
@@ -907,20 +826,20 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
+ "quote 1.0.16",
  "rustc_version 0.4.0",
- "syn 1.0.85",
+ "syn 1.0.89",
 ]
 
 [[package]]
 name = "dialoguer"
-version = "0.6.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aa86af7b19b40ef9cbef761ed411a49f0afa06b7b6dcd3dfe2f96a3c546138"
+checksum = "349d6b4fabcd9e97e1df1ae15395ac7e49fb144946a0d453959dc2696273b9da"
 dependencies = [
- "console 0.11.3",
- "lazy_static",
+ "console",
  "tempfile",
+ "zeroize",
 ]
 
 [[package]]
@@ -943,13 +862,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer 0.10.0",
+ "block-buffer 0.10.2",
  "crypto-common",
- "generic-array 0.14.5",
+ "subtle",
 ]
 
 [[package]]
@@ -1013,11 +932,10 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
+checksum = "3d5c4b5e5959dc2c2b89918d8e2cc40fcdd623cef026ed09d2f0ee05199dc8e4"
 dependencies = [
- "serde",
  "signature",
 ]
 
@@ -1027,38 +945,36 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek 3.2.0",
+ "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
  "serde",
- "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
 ]
 
 [[package]]
 name = "ed25519-dalek-bip32"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057f328f31294b5ab432e6c39642f54afd1531677d6d4ba2905932844cc242f3"
+checksum = "9d2be62a4061b872c8c0873ee4fc6f101ce7b889d039f019c5fa2af471a59908"
 dependencies = [
  "derivation-path",
  "ed25519-dalek",
- "failure",
- "hmac 0.9.0",
- "sha2 0.9.9",
+ "hmac 0.12.1",
+ "sha2 0.10.2",
 ]
 
 [[package]]
 name = "educe"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86b50932a01e7ec5c06160492ab660fb19b6bb2a7878030dd6cd68d21df9d4d"
+checksum = "c07b7cc9cd8c08d10db74fca3b20949b9b6199725c04a0cce6d543496098fcac"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -1084,46 +1000,47 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79a6321a1197d7730510c7e3f6cb80432dfefecb32426de8cea0aa19b4bb8d7"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
 dependencies = [
  "enum-iterator-derive",
 ]
 
 [[package]]
 name = "enum-iterator-derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
 name = "enum-ordinalize"
-version = "3.1.10"
+version = "3.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
+checksum = "2170fc0efee383079a8bdd05d6ea2a184d2a0f07a1c1dcabdb2fd5e9f24bc36c"
 dependencies = [
  "num-bigint",
  "num-traits",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "rustc_version 0.4.0",
+ "syn 1.0.89",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.14",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -1150,26 +1067,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
+name = "etcd-client"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+checksum = "585de5039d1ecce74773db49ba4e8107e42be7c2cd0b1a9e7fce27181db7b118"
 dependencies = [
- "backtrace",
- "failure_derive",
+ "http",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tower-service",
 ]
 
 [[package]]
-name = "failure_derive"
-version = "0.1.8"
+name = "event-listener"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
- "synstructure",
-]
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "fake-simd"
@@ -1188,21 +1104,22 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "fd-lock"
-version = "2.0.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0010f02effd88c702318c5dde0463206be67495d0b4d906ba7c0a8f166cc7f06"
+checksum = "46e245f4c8ec30c6415c56cb132c07e69e74f1942f6b4a4061da748b49f486ca"
 dependencies = [
- "libc",
- "winapi 0.3.9",
+ "cfg-if 1.0.0",
+ "rustix",
+ "windows-sys 0.30.0",
 ]
 
 [[package]]
@@ -1219,15 +1136,15 @@ checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "fixedbitset"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "flate2"
@@ -1279,28 +1196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,9 +1209,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1329,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1339,15 +1234,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1357,38 +1252,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -1401,6 +1296,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1420,14 +1324,14 @@ checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "serde",
  "typenum",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
 name = "gethostname"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -1448,20 +1352,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glob"
@@ -1478,26 +1376,26 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "fnv",
- "log 0.4.14",
+ "log",
  "regex",
 ]
 
 [[package]]
 name = "goauth"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1d5b4e896797c19dff490f9706817b42e9b7aa4adfe844464d3bbc9aabb035"
+checksum = "38f3d68c8343245dc047982651b5afb8bd659c9959ed72efe5a73bf22684e5fd"
 dependencies = [
- "arc-swap 1.5.0",
- "futures 0.3.19",
- "log 0.4.14",
+ "arc-swap",
+ "futures 0.3.21",
+ "log",
  "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
  "simpl",
  "smpl_jwt",
- "time 0.2.27",
+ "time 0.3.9",
  "tokio",
 ]
 
@@ -1507,18 +1405,18 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32401e89c6446dcd28185931a01b1093726d0356820ac744023e6850689bf926"
 dependencies = [
- "log 0.4.14",
+ "log",
  "plain",
  "scroll",
 ]
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1527,7 +1425,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -1542,20 +1440,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash 0.4.7",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
 ]
 
 [[package]]
@@ -1577,23 +1466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hidapi"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c4cc7279df8353788ac551186920e44959d5948aec404be02b28544a598bce"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,28 +1477,17 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
- "crypto-mac 0.8.0",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.9.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac 0.9.1",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
-dependencies = [
- "crypto-mac 0.10.1",
- "digest 0.9.0",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1646,9 +1507,9 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa",
 ]
 
 [[package]]
@@ -1657,16 +1518,16 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "http",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -1682,30 +1543,11 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.10.16"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
- "base64 0.9.3",
- "httparse",
- "language-tags",
- "log 0.3.9",
- "mime 0.2.6",
- "num_cpus",
- "time 0.1.44",
- "traitobject",
- "typeable",
- "unicase 1.4.2",
- "url 1.7.2",
-]
-
-[[package]]
-name = "hyper"
-version = "0.14.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
-dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1714,9 +1556,9 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa",
  "pin-project-lite",
- "socket2 0.4.2",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1730,10 +1572,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
- "hyper 0.14.16",
- "rustls 0.20.2",
+ "hyper",
+ "rustls 0.20.4",
  "tokio",
- "tokio-rustls 0.23.2",
+ "tokio-rustls 0.23.3",
 ]
 
 [[package]]
@@ -1742,7 +1584,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.16",
+ "hyper",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1754,8 +1596,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.1.0",
- "hyper 0.14.16",
+ "bytes",
+ "hyper",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -1790,10 +1632,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
-name = "indexed"
-version = "0.1.1"
+name = "im"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d480125acf340d6a6e59dab69ae19d6fca3a906e1eade277671272cc8f73794b"
+checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.5.1",
+ "rand_xoshiro",
+ "rayon",
+ "serde",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "index_list"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9d968042a4902e08810946fc7cd5851eb75e80301342305af755ca06cb82ce"
 
 [[package]]
 name = "indexmap"
@@ -1801,30 +1659,30 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
- "autocfg 1.0.1",
- "hashbrown 0.11.2",
+ "autocfg",
+ "hashbrown",
  "rayon",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.15.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
 dependencies = [
- "console 0.15.0",
+ "console",
  "lazy_static",
  "number_prefix",
  "regex",
 ]
 
 [[package]]
-name = "input_buffer"
-version = "0.3.1"
+name = "inout"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
+checksum = "9e1f03d4ab4d5dc9ec2d219f86c15d2a15fc08239d1cd3b2d6a19717c0a2f443"
 dependencies = [
- "bytes 0.5.6",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -1837,28 +1695,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
+name = "io-lifetimes"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
+checksum = "9448015e586b611e5d322f6703812bbca2f1e709d5773ecd38ddb4e3bb649504"
 
 [[package]]
 name = "ipnet"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
+checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "itertools"
@@ -1868,12 +1714,6 @@ checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -1892,11 +1732,22 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -1906,17 +1757,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
 dependencies = [
  "derive_more",
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "jsonrpc-server-utils",
- "log 0.4.14",
+ "log",
  "parity-tokio-ipc",
  "serde",
  "serde_json",
  "tokio",
  "url 1.7.2",
- "websocket",
 ]
 
 [[package]]
@@ -1925,10 +1775,10 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-executor",
  "futures-util",
- "log 0.4.14",
+ "log",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1940,7 +1790,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51da17abecbdab3e3d4f26b01c5ec075e88d3abe3ab3b05dc9aa69392764ec0"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-client-transports",
 ]
 
@@ -1952,8 +1802,8 @@ checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
 dependencies = [
  "proc-macro-crate 0.1.5",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -1962,14 +1812,14 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
 dependencies = [
- "futures 0.3.19",
- "hyper 0.14.16",
+ "futures 0.3.21",
+ "hyper",
  "jsonrpc-core",
  "jsonrpc-server-utils",
- "log 0.4.14",
+ "log",
  "net2",
  "parking_lot 0.11.2",
- "unicase 2.6.0",
+ "unicase",
 ]
 
 [[package]]
@@ -1978,10 +1828,10 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382bb0206323ca7cda3dcd7e245cea86d37d02457a02a975e3378fb149a48845"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-server-utils",
- "log 0.4.14",
+ "log",
  "parity-tokio-ipc",
  "parking_lot 0.11.2",
  "tower-service",
@@ -1993,10 +1843,10 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240f87695e6c6f62fb37f05c02c04953cf68d6408b8c1c89de85c7a0125b1011"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "parking_lot 0.11.2",
  "rand 0.7.3",
  "serde",
@@ -2008,31 +1858,16 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
 dependencies = [
- "bytes 1.1.0",
- "futures 0.3.19",
+ "bytes",
+ "futures 0.3.21",
  "globset",
  "jsonrpc-core",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "tokio",
  "tokio-stream",
- "tokio-util",
- "unicase 2.6.0",
-]
-
-[[package]]
-name = "jsonrpc-ws-server"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f892c7d766369475ab7b0669f417906302d7c0fb521285c0a0c92e52e7c8e946"
-dependencies = [
- "futures 0.3.19",
- "jsonrpc-core",
- "jsonrpc-server-utils",
- "log 0.4.14",
- "parity-ws",
- "parking_lot 0.11.2",
- "slab",
+ "tokio-util 0.6.9",
+ "unicase",
 ]
 
 [[package]]
@@ -2052,19 +1887,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lazycell"
@@ -2074,47 +1900,45 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libloading"
-version = "0.6.7"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
 ]
 
 [[package]]
-name = "libloading"
-version = "0.7.2"
+name = "libm"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
-dependencies = [
- "cfg-if 1.0.0",
- "winapi 0.3.9",
-]
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.20.3"
+version = "0.6.1+6.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c309a9d2470844aceb9a4a098cf5286154d20596868b75a6b36357d2bb9ca25d"
+checksum = "81bc587013734dadb7cf23468e531aa120788b87243648be42e2d3a072186291"
 dependencies = [
  "bindgen",
+ "bzip2-sys",
  "cc",
  "glob",
  "libc",
+ "libz-sys",
 ]
 
 [[package]]
 name = "libsecp256k1"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
+checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
 dependencies = [
  "arrayref",
  "base64 0.12.3",
@@ -2159,67 +1983,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
-name = "lock_api"
-version = "0.3.4"
+name = "linux-raw-sys"
+version = "0.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
+checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.3.9"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.14",
-]
-
-[[package]]
-name = "log"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "lru"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
+checksum = "fcb87f3080f6d1d69e8c564c0fcfde1d7aa8cc451ce40cae89479111f03bc0eb"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -2229,9 +2052,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap2"
-version = "0.1.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b70ca2a6103ac8b665dc150b142ef0e4e89df640c9e6cf295d189c3caebe5a"
+checksum = "057a3db23999c867821a7a59feb06a578fcb03685e983dff90daf9e7d24ac08f"
 dependencies = [
  "libc",
 ]
@@ -2242,16 +2065,19 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
-name = "mime"
-version = "0.2.6"
+name = "merlin"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
- "log 0.3.9",
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.3",
+ "zeroize",
 ]
 
 [[package]]
@@ -2273,26 +2099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
-]
-
-[[package]]
-name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log 0.4.14",
- "miow 0.2.2",
- "net2",
- "slab",
- "winapi 0.2.8",
+ "autocfg",
 ]
 
 [[package]]
@@ -2302,34 +2109,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
- "log 0.4.14",
- "miow 0.3.7",
+ "log",
+ "miow",
  "ntapi",
  "winapi 0.3.9",
 ]
 
 [[package]]
-name = "mio-extras"
-version = "2.0.6"
+name = "mio"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
- "lazycell",
- "log 0.4.14",
- "mio 0.6.23",
- "slab",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2339,6 +2136,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "modular-bitfield"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
+dependencies = [
+ "modular-bitfield-impl",
+ "static_assertions",
+]
+
+[[package]]
+name = "modular-bitfield-impl"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
+dependencies = [
+ "proc-macro2 1.0.36",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -2355,7 +2173,7 @@ checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.14",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -2378,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.20.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
@@ -2391,20 +2209,19 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.0"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
- "version_check 0.9.4",
 ]
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -2415,7 +2232,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2427,8 +2244,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -2437,7 +2254,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-traits",
 ]
 
@@ -2447,7 +2264,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -2462,45 +2279,45 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720d3ea1055e4e4574c0c0b0f8c3fd4f24c4cdaf465948206dea090b57b526ad"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d992b768490d7fe0d8586d9b5745f6c49f557da6d81dc982b1d167ad4edbb21"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
- "proc-macro-crate 1.1.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
 name = "number_prefix"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
-
-[[package]]
-name = "object"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "memchr",
-]
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "opaque-debug"
@@ -2530,15 +2347,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.17.0+1.1.1m"
+version = "111.18.0+1.1.1n"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
 dependencies = [
  "cc",
 ]
@@ -2549,7 +2366,7 @@ version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cc",
  "libc",
  "openssl-src",
@@ -2558,10 +2375,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "ouroboros"
-version = "0.10.1"
+name = "opentelemetry"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84236d64f1718c387232287cf036eb6632a5ecff226f4ff9dccb8c2b79ba0bde"
+checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures 0.3.21",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding 2.1.0",
+ "pin-project",
+ "rand 0.8.5",
+ "thiserror",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71643f290d126e18ac2598876d01e1d57aed164afc78fdb6e2a0c6589a1f6662"
 dependencies = [
  "aliasable",
  "ouroboros_macro",
@@ -2570,15 +2404,15 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.10.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f463857a6eb96c0136b1d56e56c718350cef30412ec065b48294799a088bca68"
+checksum = "ed9a247206016d424fe8497bc611e510887af5c261fbbf977877c4bb55ca4d82"
 dependencies = [
  "Inflector",
  "proc-macro-error",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -2587,51 +2421,12 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "libc",
- "log 0.4.14",
+ "log",
  "rand 0.7.3",
  "tokio",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "parity-ws"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5983d3929ad50f12c3eb9a6743f19d691866ecd44da74c0a3308c3f8a56df0c6"
-dependencies = [
- "byteorder",
- "bytes 0.4.12",
- "httparse",
- "log 0.4.14",
- "mio 0.6.23",
- "mio-extras",
- "rand 0.7.3",
- "sha-1 0.8.2",
- "slab",
- "url 2.2.2",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.6.2",
- "rustc_version 0.2.3",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.2",
 ]
 
 [[package]]
@@ -2641,37 +2436,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.5",
+ "lock_api",
  "parking_lot_core 0.8.5",
 ]
 
 [[package]]
-name = "parking_lot_core"
-version = "0.6.2"
+name = "parking_lot"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "rustc_version 0.2.3",
- "smallvec 0.6.14",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "smallvec 1.7.0",
- "winapi 0.3.9",
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -2683,9 +2459,22 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.10",
- "smallvec 1.7.0",
+ "redox_syscall",
+ "smallvec",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys 0.32.0",
 ]
 
 [[package]]
@@ -2694,16 +2483,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
 dependencies = [
- "crypto-mac 0.8.0",
+ "crypto-mac",
 ]
 
 [[package]]
 name = "pbkdf2"
-version = "0.6.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b8c0d71734018084da0c0354193a5edfb81b20d2d57a92c5b154aefc554a4a"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
 dependencies = [
- "crypto-mac 0.10.1",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -2711,6 +2500,15 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
+dependencies = [
+ "base64 0.13.0",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2734,10 +2532,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.5.1"
+name = "pest_derive"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2 1.0.36",
+ "quote 1.0.16",
+ "syn 1.0.89",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1 0.8.2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -2759,8 +2591,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -2776,6 +2608,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +2629,18 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polyval"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "opaque-debug 0.3.0",
+ "universal-hash",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2804,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
  "toml",
@@ -2820,9 +2675,9 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
- "version_check 0.9.4",
+ "quote 1.0.16",
+ "syn 1.0.89",
+ "version_check",
 ]
 
 [[package]]
@@ -2832,8 +2687,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "version_check 0.9.4",
+ "quote 1.0.16",
+ "version_check",
 ]
 
 [[package]]
@@ -2862,52 +2717,54 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "heck",
- "itertools 0.10.3",
- "log 0.4.14",
+ "itertools",
+ "lazy_static",
+ "log",
  "multimap",
  "petgraph",
  "prost",
  "prost-types",
+ "regex",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools 0.10.3",
+ "itertools",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "prost",
 ]
 
@@ -2921,6 +2778,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584865613896a1f644d757e52c45c573441c8b04cac38ac13990b0235203db66"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "fxhash",
+ "quinn-proto",
+ "quinn-udp",
+ "rustls 0.20.4",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b1562bf4998b0c6d1841a4742b7103bb82cdde61374833de826bab9e8ad498"
+dependencies = [
+ "bytes",
+ "fxhash",
+ "rand 0.8.5",
+ "ring",
+ "rustls 0.20.4",
+ "rustls-native-certs",
+ "rustls-pemfile 0.2.1",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df185e5e5f7611fa6e628ed8f9633df10114b03bbaecab186ec55822c44ac727"
+dependencies = [
+ "futures-util",
+ "libc",
+ "mio 0.7.14",
+ "quinn-proto",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
 dependencies = [
  "proc-macro2 1.0.36",
 ]
@@ -2946,25 +2857,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg 0.1.2",
- "rand_xorshift",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2973,30 +2865,19 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
- "rand_pcg 0.2.1",
+ "rand_hc",
+ "rand_pcg",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3021,21 +2902,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -3049,16 +2915,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.3",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
+ "getrandom 0.2.5",
 ]
 
 [[package]]
@@ -3071,59 +2928,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
 name = "rand_pcg"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3133,19 +2937,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.1.1"
+name = "rand_xoshiro"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
 dependencies = [
- "rand_core 0.3.1",
+ "rand_core 0.5.1",
 ]
-
-[[package]]
-name = "raptorq"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd204b7464360edee359a86d04f16c2c4219eb6459423b9e84b818cb4342e9c3"
 
 [[package]]
 name = "rayon"
@@ -3153,7 +2951,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -3165,63 +2963,64 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
- "crossbeam-channel 0.5.2",
+ "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.6",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
+name = "rcgen"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+checksum = "d7fa2d386df8533b02184941c76ae2e0d0c1d053f5d43339169d80f21275fc5e"
 dependencies = [
- "rand_core 0.3.1",
+ "pem",
+ "ring",
+ "time 0.3.9",
+ "yasna",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "7776223e2696f1aa4c6b0170e83212f47296a00424305117d013dfe86fb0fe55"
 dependencies = [
- "getrandom 0.2.3",
- "redox_syscall 0.2.10",
+ "getrandom 0.2.5",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
 name = "reed-solomon-erasure"
-version = "4.0.2"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
+checksum = "7170bac0d8306941e101df0caaa6518b10bc4232dd36c34f1cb78b8a063024db"
 dependencies = [
  "cc",
  "libc",
- "smallvec 1.7.0",
+ "libm",
+ "parking_lot 0.11.2",
+ "smallvec",
+ "spin 0.9.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3245,37 +3044,37 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
+checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
  "base64 0.13.0",
- "bytes 1.1.0",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
  "http",
  "http-body",
- "hyper 0.14.16",
+ "hyper",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.14",
- "mime 0.3.16",
+ "log",
+ "mime",
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
- "rustls 0.20.2",
- "rustls-pemfile",
+ "rustls 0.20.4",
+ "rustls-pemfile 0.3.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.23.2",
+ "tokio-rustls 0.23.3",
  "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3286,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "retain_mut"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11000e6ba5020e53e7cc26f73b91ae7d5496b4977851479edb66b694c0675c21"
+checksum = "8c31b5c4033f8fdde8700e4657be2c497e7288f01515be52168c631e2e4d4086"
 
 [[package]]
 name = "ring"
@@ -3299,7 +3098,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
@@ -3307,9 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c749134fda8bfc90d0de643d59bfc841dcb3ac8a1062e12b6754bd60235c48b3"
+checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -3317,11 +3116,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "4.0.5"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99371657d3c8e4d816fb6221db98fa408242b0b53bac08f8676a41f8554fe99f"
+checksum = "2bf099a1888612545b683d2661a1940089f6c2e5a8e38979b2159da876bfd956"
 dependencies = [
  "libc",
+ "serde",
+ "serde_json",
  "winapi 0.3.9",
 ]
 
@@ -3352,7 +3153,21 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.4",
+ "semver 1.0.6",
+]
+
+[[package]]
+name = "rustix"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3cc851a13d30a34cb747ba2a0c5101a4b2e8b1677a29b213ee465365ea495e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3362,7 +3177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64 0.13.0",
- "log 0.4.14",
+ "log",
  "ring",
  "sct 0.6.1",
  "webpki 0.21.4",
@@ -3370,14 +3185,26 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.2"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
+checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
- "log 0.4.14",
+ "log",
  "ring",
  "sct 0.7.0",
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca9ebdfa27d3fc180e42879037b5338ab1c040c06affd00d8338598e7800943"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 0.2.1",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3385,6 +3212,15 @@ name = "rustls-pemfile"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64 0.13.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
 dependencies = [
  "base64 0.13.0",
 ]
@@ -3400,12 +3236,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -3448,8 +3278,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -3474,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.3.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3487,9 +3317,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.2"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3501,23 +3331,14 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
+ "semver-parser",
 ]
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "semver-parser"
@@ -3526,19 +3347,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
-
-[[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -3554,34 +3366,34 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 0.4.8",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3624,10 +3436,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
+name = "sha-1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -3644,13 +3476,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.1",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -3666,6 +3498,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
+dependencies = [
+ "digest 0.10.3",
+ "keccak",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,9 +3524,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.17"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
+checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3703,6 +3554,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a30f10c911c0355f80f1c2faa8096efc4a58cdf8590b954d5b395efa071c711"
 
 [[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3710,18 +3571,9 @@ checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
-version = "0.6.14"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "smpl_jwt"
@@ -3730,7 +3582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4370044f8b20f944e05c35d77edd3518e6f21fc4de77e593919f287c6a3f428a"
 dependencies = [
  "base64 0.13.0",
- "log 0.4.14",
+ "log",
  "openssl",
  "serde",
  "serde_derive",
@@ -3741,20 +3593,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -3762,29 +3603,29 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74e48087dbeed4833785c2f3352b59140095dc192dce966a3bfc155020a439f"
+checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
  "base64 0.13.0",
- "bytes 1.1.0",
- "futures 0.3.19",
+ "bytes",
+ "futures 0.3.21",
  "httparse",
- "log 0.4.14",
- "rand 0.8.4",
+ "log",
+ "rand 0.8.5",
  "sha-1 0.9.8",
 ]
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4c1304620ee4a570462869615f3ce1b4c3500c8675110425d7aff99a2c38679"
+checksum = "791e2b5edea984a99fdc2bc312635496d08909a6e5fafe6f5efb16d1c15ee52b"
 dependencies = [
  "Inflector",
- "base64 0.12.3",
+ "base64 0.13.0",
  "bincode",
- "bs58 0.3.1",
+ "bs58",
  "bv",
  "lazy_static",
  "serde",
@@ -3799,64 +3640,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-accountsdb-plugin-interface"
-version = "1.8.14"
+name = "solana-address-lookup-table-program"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badd9186d2740f830a26e599ff826935aebdd287b5f9414fe4213536f0923763"
+checksum = "40b02ce7aaea0431d564cf75b8f597cd43029bf97c731acf83a3229514d46b48"
 dependencies = [
- "log 0.4.14",
- "thiserror",
-]
-
-[[package]]
-name = "solana-accountsdb-plugin-manager"
-version = "1.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb5c032c5ba175f239491ffe4152b386ae876fc4bc8cc172d9b83ad49364b53"
-dependencies = [
- "bs58 0.4.0",
- "crossbeam-channel 0.4.4",
- "libloading 0.7.2",
- "log 0.4.14",
+ "bincode",
+ "bytemuck",
+ "log",
+ "num-derive",
+ "num-traits",
+ "rustc_version 0.4.0",
  "serde",
- "serde_derive",
- "serde_json",
- "solana-accountsdb-plugin-interface",
- "solana-logger",
- "solana-measure",
- "solana-metrics",
- "solana-rpc",
- "solana-runtime",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-program",
+ "solana-program-runtime",
  "solana-sdk",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-banks-client"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55a64726bfffacf62fdca86e9d56e04bedc4c50fc0b7ec103cde15a9978c111"
+checksum = "bd6410f82aa40c99bb70b673f043728bf5f87f7dfab33cd2ec99f2e298f5efab"
 dependencies = [
- "bincode",
  "borsh",
- "borsh-derive",
- "futures 0.3.19",
- "mio 0.7.14",
+ "futures 0.3.21",
  "solana-banks-interface",
  "solana-program",
  "solana-sdk",
  "tarpc",
+ "thiserror",
  "tokio",
  "tokio-serde",
 ]
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1ff95798aa951d91f92b1839961ac7bd7839b4811b9b5756017bd7ada3a5a8"
+checksum = "9c8d9f74545f0487f752ea11db03fe2be9150012d42414d132d30ea6e91091b0"
 dependencies = [
- "mio 0.7.14",
  "serde",
  "solana-sdk",
  "tarpc",
@@ -3864,18 +3690,17 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950d707b7b811e4a64e6d5d6a4608e14c54e729b0457657e9e656758900be268"
+checksum = "d760384a0b3a52c030a1b7c4019b0614cc60bee0a53420c37d394ff63e4644a2"
 dependencies = [
  "bincode",
- "futures 0.3.19",
- "log 0.4.14",
- "mio 0.7.14",
+ "crossbeam-channel",
+ "futures 0.3.21",
  "solana-banks-interface",
- "solana-metrics",
  "solana-runtime",
  "solana-sdk",
+ "solana-send-transaction-service",
  "tarpc",
  "tokio",
  "tokio-serde",
@@ -3884,13 +3709,13 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe05f0c59be2ab5283756a707e12ecb39706bfa4f73af668c43738446f7f6521"
+checksum = "26fd01402bc53b16237978cbcd699c7390ee152f85cb0c51fbf13a4f4a4c38ec"
 dependencies = [
  "bv",
  "fnv",
- "log 0.4.14",
+ "log",
  "rand 0.7.3",
  "rayon",
  "rustc_version 0.4.0",
@@ -3903,31 +3728,43 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed064fada9e8cc27a3253b33b6ecb68d0195d4c846f8fde41ca3b1f3e0ef9fbb"
+checksum = "0c7176038553fd50c6dfc68b9adae6af62ba92f61710120c872a2b257ab2f597"
 dependencies = [
  "bincode",
  "byteorder",
  "libsecp256k1",
- "log 0.4.14",
- "num-derive",
- "num-traits",
- "rand_core 0.6.3",
- "sha3",
+ "log",
  "solana-measure",
  "solana-metrics",
- "solana-runtime",
+ "solana-program-runtime",
  "solana-sdk",
+ "solana-zk-token-sdk",
  "solana_rbpf",
  "thiserror",
 ]
 
 [[package]]
-name = "solana-clap-utils"
-version = "1.8.14"
+name = "solana-bucket-map"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d5da8ba4565446a2a7c0e89853ba255fc5ef5063509bb36e74e143735b0013"
+checksum = "0f0e29f0594ad7a59db5aa55c0498ac5db031fc2e63fcb474b69a402d013b2db"
+dependencies = [
+ "log",
+ "memmap2",
+ "modular-bitfield",
+ "rand 0.7.3",
+ "solana-measure",
+ "solana-sdk",
+ "tempfile",
+]
+
+[[package]]
+name = "solana-clap-utils"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "657cf03ebd6024dcb235eb0f1ca90afedcaf772f7825f23e1fee3a3ba3284500"
 dependencies = [
  "chrono",
  "clap",
@@ -3943,9 +3780,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f6ac179411758ad6a4ad8033974ea16e17f0b72e40be404a9c9fe4665daa1"
+checksum = "26bee6638ef60c331203911df468210f6eba141034f0af6560283376c33866e7"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -3956,28 +3793,64 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-client"
-version = "1.8.14"
+name = "solana-cli-output"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f03617eeca735cd62370d135bdc18ee9bd3639d45ceff4034b0bb095e534df"
+checksum = "75b41b1ccac4dfbc197b41bcf16d10f258e8fb042c24c4378d251d40afff002a"
 dependencies = [
+ "Inflector",
+ "base64 0.13.0",
+ "chrono",
+ "clap",
+ "console",
+ "humantime",
+ "indicatif",
+ "serde",
+ "serde_json",
+ "solana-account-decoder",
+ "solana-clap-utils",
+ "solana-client",
+ "solana-sdk",
+ "solana-transaction-status",
+ "solana-vote-program",
+ "spl-memo",
+]
+
+[[package]]
+name = "solana-client"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34010feef06fab6939c8a82d12a568b0ed825b3d11d3fac592566c6c63f98d2"
+dependencies = [
+ "async-mutex",
+ "async-trait",
  "base64 0.13.0",
  "bincode",
- "bs58 0.3.1",
+ "bs58",
+ "bytes",
  "clap",
+ "crossbeam-channel",
+ "futures 0.3.21",
+ "futures-util",
  "indicatif",
+ "itertools",
  "jsonrpc-core",
- "log 0.4.14",
- "net2",
+ "lazy_static",
+ "log",
+ "quinn",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
  "rayon",
  "reqwest",
- "semver 0.11.0",
+ "rustls 0.20.4",
+ "semver 1.0.6",
  "serde",
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
  "solana-clap-utils",
  "solana-faucet",
+ "solana-measure",
  "solana-net-utils",
  "solana-sdk",
  "solana-transaction-status",
@@ -3985,163 +3858,141 @@ dependencies = [
  "solana-vote-program",
  "thiserror",
  "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
  "tungstenite",
  "url 2.2.2",
 ]
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03bbba7d245abb7b6b9384ce6bca76f8bec34f8aa5e933613c3bf0ac1b58ba77"
+checksum = "2b9efaad0b36bb502b61b8732cd9784b6bc2014eceee2b150c5d0d23a67834cf"
 dependencies = [
+ "solana-program-runtime",
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-config-program"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9fccdec6f246264b289b3d2ff7e9f23b7f5cd5c150c6245db38d27396dfd25"
+checksum = "b67187893a8155f5b1203e61d6c0ea77377df05abe1075426ec94d6af2379164"
 dependencies = [
  "bincode",
  "chrono",
- "log 0.4.14",
- "rand_core 0.6.3",
  "serde",
  "serde_derive",
+ "solana-program-runtime",
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-core"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae060c6e73084fc376f88493ec253b2e5e4cad0d924ca1ee6ff4a6ad1deb60bf"
+checksum = "762a5b8190bb253b599d58ed3731af0ee4cdf9a892af7accfd980001b04b9996"
 dependencies = [
- "ahash 0.6.3",
- "base64 0.12.3",
+ "ahash",
+ "base64 0.13.0",
  "bincode",
- "blake3",
- "bs58 0.3.1",
- "bv",
- "byteorder",
+ "bs58",
  "chrono",
- "crossbeam-channel 0.4.4",
- "ed25519-dalek",
- "flate2",
+ "crossbeam-channel",
+ "dashmap",
+ "etcd-client",
  "fs_extra",
  "histogram",
- "indexmap",
- "itertools 0.10.3",
- "libc",
- "log 0.4.14",
+ "itertools",
+ "log",
  "lru",
- "miow 0.2.2",
- "net2",
- "num-traits",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
- "rand_core 0.6.3",
- "raptorq",
  "rayon",
  "retain_mut",
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
  "serde",
- "serde_bytes",
  "serde_derive",
- "solana-account-decoder",
- "solana-accountsdb-plugin-manager",
- "solana-banks-server",
+ "solana-address-lookup-table-program",
  "solana-bloom",
- "solana-clap-utils",
  "solana-client",
+ "solana-entry",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-ledger",
- "solana-logger",
  "solana-measure",
- "solana-merkle-tree",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
  "solana-poh",
- "solana-program-test",
+ "solana-program-runtime",
  "solana-rayon-threadlimit",
+ "solana-replica-lib",
  "solana-rpc",
  "solana-runtime",
  "solana-sdk",
+ "solana-send-transaction-service",
  "solana-streamer",
  "solana-transaction-status",
- "solana-version",
  "solana-vote-program",
- "spl-token",
  "sys-info",
+ "sysctl",
  "tempfile",
  "thiserror",
+ "tokio",
  "trees",
 ]
 
 [[package]]
-name = "solana-crate-features"
-version = "1.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7aacb3780ddb5b5f1271bd1245571de59dfafd1ccea6b9ca311292e6257752"
-dependencies = [
- "backtrace",
- "bytes 0.4.12",
- "cc",
- "curve25519-dalek 2.1.3",
- "ed25519-dalek",
- "either",
- "lazy_static",
- "libc",
- "rand_chacha 0.2.2",
- "regex-syntax",
- "reqwest",
- "ring",
- "serde",
- "syn 0.15.44",
- "syn 1.0.85",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "solana-download-utils"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b652bfa75e1302e79b4130a6a234e58f46b6463489e641d1183be0d188283c"
+checksum = "df6b8056caa1e9e041e91d551b8ab7f52a797f8ba1e091d04de20a6cf2e09ecf"
 dependencies = [
- "bzip2",
- "console 0.14.1",
+ "console",
  "indicatif",
- "log 0.4.14",
+ "log",
  "reqwest",
  "solana-runtime",
  "solana-sdk",
- "tar",
 ]
 
 [[package]]
-name = "solana-ed25519-program"
-version = "1.8.14"
+name = "solana-entry"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a29981f1d2b22b620d6ca786fcdc1a3313f0ec084fe98727be40cce165f3e99"
+checksum = "3b37e2131a2544ff6c72b12f222ed89113d7ff4ff05275ecea235afe760ae7d2"
 dependencies = [
+ "bincode",
+ "crossbeam-channel",
+ "dlopen",
+ "dlopen_derive",
+ "log",
+ "rand 0.7.3",
+ "rayon",
+ "serde",
+ "solana-measure",
+ "solana-merkle-tree",
+ "solana-metrics",
+ "solana-perf",
+ "solana-rayon-threadlimit",
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-faucet"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cac397bcaf0f5e560639ae691235a13cd7042fd97dab4b900018fb414e3b72b"
+checksum = "de57b3f9a68b86d3729c300aae3cb6410881502b4ac88a98fe7175514788d962"
 dependencies = [
  "bincode",
  "byteorder",
  "clap",
- "log 0.4.14",
+ "crossbeam-channel",
+ "log",
  "serde",
  "serde_derive",
  "solana-clap-utils",
@@ -4157,41 +4008,42 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3495c76034ef52472ff4c5cd82f513073b415a7ac962d9a8aefe906a216e6392"
+checksum = "b1dc3f3f3e0f9f773cdcf594a7c5fe61a129903092efdb747d380ab89b15196b"
 dependencies = [
- "bs58 0.3.1",
+ "bs58",
  "bv",
  "generic-array 0.14.5",
- "log 0.4.14",
+ "im",
+ "lazy_static",
+ "log",
  "memmap2",
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "sha2 0.9.9",
+ "sha2 0.10.2",
  "solana-frozen-abi-macro",
- "solana-logger",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2193bd0e23b5bc93fce0533248c43b8aa53b27a91298e49d6fd018f51c43138"
+checksum = "b2d6b3a8b2ec9601417443e1ddc3ffa92b44a68a5fad467bee71d00f12cb1cdd"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "rustc_version 0.2.3",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "rustc_version 0.4.0",
+ "syn 1.0.89",
 ]
 
 [[package]]
 name = "solana-genesis-utils"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18feea32cc27dd87a952804afe722ac5be80014376bf6710e29e13cc390639c5"
+checksum = "7bc76a987e333fc8caec89918921707706509d65577a2fb44fa29e9fb830cfc5"
 dependencies = [
  "solana-download-utils",
  "solana-runtime",
@@ -4199,31 +4051,67 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-gossip"
-version = "1.8.14"
+name = "solana-geyser-plugin-interface"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa14d9c55a8f885d9fcb95a35231778cc995251f51a08e954abf4a82b585397"
+checksum = "fdca0fa6dc0d93824aef15c437f8d2bfaf25df1510b2265055c1bd75011e2135"
+dependencies = [
+ "log",
+ "solana-sdk",
+ "solana-transaction-status",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-geyser-plugin-manager"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d1633af6e46026122b40b49090cdc4acd9e7eca8ea03e8b9436f19c80c350"
+dependencies = [
+ "bs58",
+ "crossbeam-channel",
+ "json5",
+ "libloading",
+ "log",
+ "serde_json",
+ "solana-geyser-plugin-interface",
+ "solana-measure",
+ "solana-metrics",
+ "solana-rpc",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-transaction-status",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-gossip"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26e3fbba6a762125e787399e817fb4f0048dcc108b2aaebd5f94fb230a8ab32"
 dependencies = [
  "bincode",
  "bv",
  "clap",
+ "crossbeam-channel",
  "flate2",
  "indexmap",
- "itertools 0.10.3",
- "log 0.4.14",
+ "itertools",
+ "log",
  "lru",
  "matches",
  "num-traits",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rayon",
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
  "serde",
  "serde_bytes",
  "serde_derive",
  "solana-bloom",
  "solana-clap-utils",
  "solana-client",
+ "solana-entry",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-ledger",
@@ -4243,25 +4131,21 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12745bd3324343bca323517047f82666c56b7fb07aabf60cc8791f51c9d6447f"
+checksum = "09b00d758860767160432b376dd9bab3916b4927d18db6020f943cffcd4d914a"
 dependencies = [
  "bincode",
  "byteorder",
  "chrono",
  "chrono-humanize",
- "crossbeam-channel 0.4.4",
- "dlopen",
- "dlopen_derive",
- "ed25519-dalek",
+ "crossbeam-channel",
  "fs_extra",
- "futures 0.3.19",
- "futures-util",
- "itertools 0.9.0",
+ "futures 0.3.21",
+ "itertools",
  "lazy_static",
  "libc",
- "log 0.4.14",
+ "log",
  "num-derive",
  "num-traits",
  "num_cpus",
@@ -4271,18 +4155,18 @@ dependencies = [
  "rayon",
  "reed-solomon-erasure",
  "rocksdb",
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
  "serde",
  "serde_bytes",
- "sha2 0.9.9",
+ "sha2 0.10.2",
  "solana-bpf-loader-program",
+ "solana-entry",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-logger",
  "solana-measure",
- "solana-merkle-tree",
  "solana-metrics",
  "solana-perf",
+ "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-runtime",
  "solana-sdk",
@@ -4299,31 +4183,30 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4adacba4cc6b9d39899718fff3e312b32496ae44e570dfeff23d8b7ac60ad79"
+checksum = "95ac8ff3f79f61c2581f264642b3e897135b29618fc680fe7de92db075ec70c0"
 dependencies = [
  "env_logger",
  "lazy_static",
- "log 0.4.14",
+ "log",
 ]
 
 [[package]]
 name = "solana-measure"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd8f16859d4e84f5552ca911889052f2b60b84676ca17225ad67c3060283208"
+checksum = "6e0d9de46fba5c1a413843c7bcc288e21a9c4d632f6a8cb279000541237b1f52"
 dependencies = [
- "log 0.4.14",
- "solana-metrics",
+ "log",
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7ba44c753d14d4b8f9a3e6b386db2d21a56b0a118bd3d1aa4c72f9cd2b43c8"
+checksum = "bc5f9c8290395e1fde427db99e092a7398d584daad33be2c6fbda5f7f0bc4f47"
 dependencies = [
  "fast-math",
  "matches",
@@ -4332,33 +4215,33 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd4d8a176edc331f2edad8f25d764c91eb8b185c5161f24b5eb8d5a32870c282"
+checksum = "43fbd3205ab87c301a0d2e1ad11b0d9fc81687b712e76c2475b3e98680686e04"
 dependencies = [
- "env_logger",
+ "crossbeam-channel",
  "gethostname",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "reqwest",
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-net-utils"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cab35690808e345750435b451b441f8fe6c32ddafe6f2b724ac9d8e2fad1eeb"
+checksum = "baba2cee88e8fe8171f05684e79d37950b4a7f5173bb20c5908c35eb6fff419d"
 dependencies = [
  "bincode",
  "clap",
- "log 0.4.14",
+ "crossbeam-channel",
+ "log",
  "nix",
  "rand 0.7.3",
  "serde",
  "serde_derive",
- "socket2 0.3.19",
- "solana-clap-utils",
+ "socket2",
  "solana-logger",
  "solana-sdk",
  "solana-version",
@@ -4368,25 +4251,25 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3aaa73acee6e4ced74f607ef53b3bbac0b8598bff06c95c790e8068d9c5a948"
+checksum = "e2e3e72d26ae2cf33044e70318d0e1b2a7719054041c3c5cc71f63fd992ce16a"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
  "bincode",
+ "bv",
  "caps",
- "curve25519-dalek 2.1.3",
+ "curve25519-dalek",
  "dlopen",
  "dlopen_derive",
+ "fnv",
  "lazy_static",
  "libc",
- "log 0.4.14",
+ "log",
  "nix",
  "rand 0.7.3",
  "rayon",
  "serde",
- "solana-bloom",
- "solana-logger",
  "solana-metrics",
  "solana-rayon-threadlimit",
  "solana-sdk",
@@ -4395,13 +4278,14 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b98a0b5fee83f828f2ef5c9cebcdf87386f7e7217971a05f6dbd790be097f6"
+checksum = "4153cd406d9162fa08070f1ee490ef0ebd03acefd53d136944a6f46314038548"
 dependencies = [
  "core_affinity",
- "crossbeam-channel 0.4.4",
- "log 0.4.14",
+ "crossbeam-channel",
+ "log",
+ "solana-entry",
  "solana-ledger",
  "solana-measure",
  "solana-metrics",
@@ -4413,60 +4297,87 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f706757ff4b34f0f1fac72204bb2bfbda3c1a939c6c72ae25f1b31635d08bb"
+checksum = "a913f8dc9b99c2e5015c506a4489683cdb3ba55e898664c106e6e0203ac93bd0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
+ "bitflags",
  "blake3",
  "borsh",
  "borsh-derive",
- "bs58 0.3.1",
+ "bs58",
  "bv",
  "bytemuck",
- "curve25519-dalek 2.1.3",
- "hex",
- "itertools 0.9.0",
+ "console_error_panic_hook",
+ "console_log",
+ "curve25519-dalek",
+ "getrandom 0.1.16",
+ "itertools",
+ "js-sys",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.14",
+ "log",
  "num-derive",
  "num-traits",
+ "parking_lot 0.12.0",
  "rand 0.7.3",
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
  "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
- "sha2 0.9.9",
- "sha3",
+ "sha2 0.10.2",
+ "sha3 0.10.1",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-logger",
  "solana-sdk-macro",
+ "thiserror",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-program-runtime"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eebe1605e9e85cb35f1e268890c1332a3670662d06f956ab353afd6383757ac"
+dependencies = [
+ "base64 0.13.0",
+ "bincode",
+ "enum-iterator",
+ "itertools",
+ "libc",
+ "libloading",
+ "log",
+ "num-derive",
+ "num-traits",
+ "rustc_version 0.4.0",
+ "serde",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-measure",
+ "solana-sdk",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cc0fadfe60422f263f748ec701adf037abe7c0e8ff147e8be2b2dd65659c58"
+checksum = "54e172baf16ec09bac3caffd4f71013962241700c3553841df040425a1263c6a"
 dependencies = [
  "async-trait",
- "base64 0.12.3",
+ "base64 0.13.0",
  "bincode",
- "chrono",
  "chrono-humanize",
- "log 0.4.14",
- "mio 0.7.14",
+ "log",
  "serde",
- "serde_derive",
  "solana-banks-client",
  "solana-banks-server",
  "solana-bpf-loader-program",
  "solana-logger",
+ "solana-program-runtime",
  "solana-runtime",
  "solana-sdk",
  "solana-vote-program",
@@ -4476,9 +4387,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "012936dd1e5ee19682ba4d09ee628c2ef33ba64988e38415efa6905084f3b283"
+checksum = "17da01f1c09b5006059c39ab242c398dbc7bee8791944caab9a598f5558c1864"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -4486,45 +4397,60 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f009d977623835959420767d1d9db3b19b3cdac9ff57701f2449d453a2c2d7ee"
+checksum = "623cdf8a7f32e8fb81a28f63c145d339b1c25f7c59217d7f55e6007cf2bd241e"
 dependencies = [
- "base32",
- "console 0.14.1",
+ "console",
  "dialoguer",
- "hidapi",
- "log 0.4.14",
+ "log",
  "num-derive",
  "num-traits",
- "parking_lot 0.10.2",
+ "parking_lot 0.12.0",
  "qstring",
- "semver 0.9.0",
+ "semver 1.0.6",
  "solana-sdk",
  "thiserror",
  "uriparse",
 ]
 
 [[package]]
-name = "solana-rpc"
-version = "1.8.14"
+name = "solana-replica-lib"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e40477636b6badaf5dc41c45fc22bf14e72f13e58dd72372a96dc6cfe070c0"
+checksum = "24d29c6c4d961d51db39800966fc391c344fbf3efd35d68f286aae1f9fb929e6"
 dependencies = [
- "base64 0.12.3",
+ "crossbeam-channel",
+ "futures-util",
+ "log",
+ "prost",
+ "solana-rpc",
+ "solana-runtime",
+ "solana-sdk",
+ "tokio",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
+name = "solana-rpc"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "932734b35fd8f6c917c819374748a57d10c906884e36cfcfd024db4a4d9ca3ca"
+dependencies = [
+ "base64 0.13.0",
  "bincode",
- "bs58 0.3.1",
- "crossbeam-channel 0.4.4",
+ "bs58",
+ "crossbeam-channel",
  "dashmap",
- "itertools 0.9.0",
+ "itertools",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "jsonrpc-http-server",
  "jsonrpc-pubsub",
- "jsonrpc-ws-server",
  "libc",
- "log 0.4.14",
+ "log",
  "rayon",
  "regex",
  "serde",
@@ -4533,6 +4459,7 @@ dependencies = [
  "soketto",
  "solana-account-decoder",
  "solana-client",
+ "solana-entry",
  "solana-faucet",
  "solana-gossip",
  "solana-ledger",
@@ -4543,6 +4470,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-runtime",
  "solana-sdk",
+ "solana-send-transaction-service",
  "solana-storage-bigtable",
  "solana-streamer",
  "solana-transaction-status",
@@ -4552,31 +4480,32 @@ dependencies = [
  "stream-cancel",
  "thiserror",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
 name = "solana-runtime"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c534268069387e3f72a3c68a03e3d255b821730b8cc509ebec892a8facbb1300"
+checksum = "4915bef728e4d4c5026e91867a49f0f8265ab96b8c23d7fe9f36ef6df7f411e5"
 dependencies = [
  "arrayref",
  "bincode",
  "blake3",
  "bv",
+ "bytemuck",
  "byteorder",
  "bzip2",
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "dashmap",
  "dir-diff",
  "flate2",
  "fnv",
- "itertools 0.10.3",
+ "im",
+ "index_list",
+ "itertools",
  "lazy_static",
- "libc",
- "libloading 0.6.7",
- "log 0.4.14",
+ "log",
  "memmap2",
  "num-derive",
  "num-traits",
@@ -4585,23 +4514,24 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "regex",
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-bloom",
+ "solana-address-lookup-table-program",
+ "solana-bucket-map",
  "solana-compute-budget-program",
  "solana-config-program",
- "solana-ed25519-program",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-logger",
  "solana-measure",
  "solana-metrics",
+ "solana-program-runtime",
  "solana-rayon-threadlimit",
  "solana-sdk",
- "solana-secp256k1-program",
  "solana-stake-program",
  "solana-vote-program",
+ "solana-zk-token-proof-program",
+ "solana-zk-token-sdk",
  "symlink",
  "tar",
  "tempfile",
@@ -4611,48 +4541,45 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a0f8b4cd2eed1b5e5ea5674cc9e38018645922aa1db4b93d06a741ae8b7fe8"
+checksum = "a29a933be26bf7e47976338206fdefec4310c0f0e38f10f8b6d3d7c7f999f05b"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
  "bincode",
+ "bitflags",
  "borsh",
- "borsh-derive",
- "bs58 0.4.0",
- "bv",
+ "bs58",
  "bytemuck",
  "byteorder",
  "chrono",
  "derivation-path",
- "digest 0.9.0",
+ "digest 0.10.3",
  "ed25519-dalek",
  "ed25519-dalek-bip32",
  "generic-array 0.14.5",
- "hex",
- "hmac 0.10.1",
- "itertools 0.9.0",
+ "hmac 0.12.1",
+ "itertools",
+ "js-sys",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.14",
+ "log",
  "memmap2",
  "num-derive",
  "num-traits",
- "pbkdf2 0.6.0",
+ "pbkdf2 0.10.1",
  "qstring",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
- "rand_core 0.6.3",
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
  "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2 0.9.9",
- "sha3",
- "solana-crate-features",
+ "sha2 0.10.2",
+ "sha3 0.10.1",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-logger",
@@ -4660,47 +4587,53 @@ dependencies = [
  "solana-sdk-macro",
  "thiserror",
  "uriparse",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc226c8458927a632f152e44c80b5eb69e1ea74af444a026a617dd5d691bd9"
+checksum = "c8738a07927f1f8fe5ef7c2c50cc196c665cf39a07d7f9dc45e8a6345f9b0098"
 dependencies = [
- "bs58 0.3.1",
+ "bs58",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
+ "quote 1.0.16",
  "rustversion",
- "syn 1.0.85",
+ "syn 1.0.89",
 ]
 
 [[package]]
-name = "solana-secp256k1-program"
-version = "1.8.14"
+name = "solana-send-transaction-service"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd21f5828bd41811bf3847b69a8971cabc976fb62a616904bf7b39ea3da4cf0"
+checksum = "630acc389e5fc0e5f1b936abae5a006f2b41377e323aee36b70a1ae542d60655"
 dependencies = [
+ "crossbeam-channel",
+ "log",
+ "solana-metrics",
+ "solana-runtime",
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a563363277e9d933fc1487b682ce9b7e2ae7a832d64fcbbe9a27d1fd4397d1"
+checksum = "b690898c0210f89908910c4583939992ec3a19f36a178e96592628ceb35c10a7"
 dependencies = [
  "bincode",
- "log 0.4.14",
+ "log",
  "num-derive",
  "num-traits",
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
  "serde",
  "serde_derive",
  "solana-config-program",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-metrics",
+ "solana-program-runtime",
  "solana-sdk",
  "solana-vote-program",
  "thiserror",
@@ -4708,23 +4641,20 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2858f9e9a41c19313bc208c766659a2455bb123c0e0eaa094381ca6017758829"
+checksum = "ab5aa7a518fd2525f633958fbe5c75b03c082d9859c455efd46a37f9f93dfaf9"
 dependencies = [
- "arc-swap 0.4.8",
  "backoff",
  "bincode",
  "bzip2",
  "enum-iterator",
  "flate2",
- "futures 0.3.19",
  "goauth",
- "log 0.4.14",
+ "log",
  "openssl",
  "prost",
  "prost-types",
- "rand_core 0.6.3",
  "serde",
  "serde_derive",
  "smpl_jwt",
@@ -4739,15 +4669,14 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd07f5f75f991e773cac8a1116c680a38c048cf71df8937ef78cf6b828f94454"
+checksum = "9eec1b8f59cf455b5a37a262b6a0c736f14da36f0f04bbd811ec5a511bac1721"
 dependencies = [
  "bincode",
- "bs58 0.3.1",
+ "bs58",
  "prost",
  "serde",
- "serde_derive",
  "solana-account-decoder",
  "solana-sdk",
  "solana-transaction-status",
@@ -4756,33 +4685,40 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb62913cc773d169e358725548cfbee99ccc46a1d2a55cf68236ee58f056f2c"
+checksum = "1026637a4151c3dd0aadcd2225c3bfa9cb95122eaf9254b87e8c38ae64b05e37"
 dependencies = [
- "itertools 0.10.3",
+ "crossbeam-channel",
+ "futures-util",
+ "histogram",
+ "itertools",
  "libc",
- "log 0.4.14",
+ "log",
  "nix",
- "solana-logger",
- "solana-measure",
+ "pem",
+ "pkcs8",
+ "quinn",
+ "rand 0.7.3",
+ "rcgen",
+ "rustls 0.20.4",
  "solana-metrics",
  "solana-perf",
  "solana-sdk",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
 name = "solana-sys-tuner"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061edbfc913ad5cb9440811ac0c9474457385c21304921008e49fd4669d00291"
+checksum = "8fa2cef55af0ffa650c537cbb0dc1c1801b8256b4794bc83f8baebc4ff95b578"
 dependencies = [
  "clap",
  "libc",
- "log 0.4.14",
+ "log",
  "nix",
- "solana-clap-utils",
  "solana-logger",
  "solana-version",
  "sysctl",
@@ -4791,17 +4727,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-transaction-status"
-version = "1.8.14"
+name = "solana-test-validator"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6e2dd8d443b576cf6690bf21ee0251dfeeb4d98c6fc256d9746bb2d9b462a5"
+checksum = "28a18ee0030854477f49f449d462d7cec21835220066be742c308a45d784f9b0"
+dependencies = [
+ "base64 0.13.0",
+ "log",
+ "serde_derive",
+ "serde_json",
+ "solana-cli-output",
+ "solana-client",
+ "solana-core",
+ "solana-gossip",
+ "solana-ledger",
+ "solana-logger",
+ "solana-net-utils",
+ "solana-program-test",
+ "solana-rpc",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-streamer",
+ "tokio",
+]
+
+[[package]]
+name = "solana-transaction-status"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9b6aceebb09f42a255a7d492e5e5290d5c1d72abad4502126e2d93ffb26d4e"
 dependencies = [
  "Inflector",
- "base64 0.12.3",
+ "base64 0.13.0",
  "bincode",
- "bs58 0.3.1",
+ "bs58",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4819,16 +4780,15 @@ dependencies = [
 
 [[package]]
 name = "solana-validator"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382e03c992fd3436823aa046f73c10ccffd5478284aaf032d583b17694550ce0"
+checksum = "c81076bbda773e9f56f4f6a344006f26fad2fc73d9fcc5738ebe92a8df6e8643"
 dependencies = [
- "base64 0.12.3",
- "bincode",
  "chrono",
  "clap",
- "console 0.14.1",
+ "console",
  "core_affinity",
+ "crossbeam-channel",
  "fd-lock",
  "indicatif",
  "jsonrpc-core",
@@ -4837,7 +4797,7 @@ dependencies = [
  "jsonrpc-ipc-server",
  "jsonrpc-server-utils",
  "libc",
- "log 0.4.14",
+ "log",
  "num_cpus",
  "rand 0.7.3",
  "serde",
@@ -4848,6 +4808,7 @@ dependencies = [
  "solana-client",
  "solana-core",
  "solana-download-utils",
+ "solana-entry",
  "solana-faucet",
  "solana-genesis-utils",
  "solana-gossip",
@@ -4857,10 +4818,13 @@ dependencies = [
  "solana-net-utils",
  "solana-perf",
  "solana-poh",
+ "solana-replica-lib",
  "solana-rpc",
  "solana-runtime",
  "solana-sdk",
+ "solana-send-transaction-service",
  "solana-streamer",
+ "solana-test-validator",
  "solana-version",
  "solana-vote-program",
  "symlink",
@@ -4869,58 +4833,102 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1639798878b48fbf66f5d93df1b86209f722afe265d31eb6ab6d41d5c032747"
+checksum = "ad56b7c034d999d33b796e1af2613ab6ea04fd9cbf49012dc52f83a905f5b3ee"
 dependencies = [
- "log 0.4.14",
- "rustc_version 0.2.3",
+ "log",
+ "rustc_version 0.4.0",
  "serde",
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-logger",
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "1.8.14"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ec510e5dc644aa423260e01ac10341f56b2d16ac796e74cdaa41f603a61ffbf"
+checksum = "23320e8fe67fb7b79b196556abb119a1b0ed10f425cee5254b69e0efcf444e4f"
 dependencies = [
  "bincode",
- "log 0.4.14",
+ "log",
  "num-derive",
  "num-traits",
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
  "serde",
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-logger",
  "solana-metrics",
+ "solana-program-runtime",
  "solana-sdk",
  "thiserror",
 ]
 
 [[package]]
-name = "solana_rbpf"
-version = "0.2.21"
+name = "solana-zk-token-proof-program"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb565d026461ba89d1d92cc36cf0882fba44076559c3bbed1e8a9888112b3d7"
+checksum = "d26323871756714ae5485a3d256bed40bb58da096629cb805285253e97073713"
+dependencies = [
+ "bytemuck",
+ "getrandom 0.1.16",
+ "num-derive",
+ "num-traits",
+ "solana-program-runtime",
+ "solana-sdk",
+ "solana-zk-token-sdk",
+]
+
+[[package]]
+name = "solana-zk-token-sdk"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32bc2b7ed28a714aead56ff813fa2550859aa95ccf8f3ae63fe36f130ead57b6"
+dependencies = [
+ "aes-gcm-siv",
+ "arrayref",
+ "base64 0.13.0",
+ "bincode",
+ "bytemuck",
+ "byteorder",
+ "cipher 0.4.3",
+ "curve25519-dalek",
+ "getrandom 0.1.16",
+ "lazy_static",
+ "merlin",
+ "num-derive",
+ "num-traits",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "sha3 0.9.1",
+ "solana-program",
+ "solana-sdk",
+ "subtle",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "solana_rbpf"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e138f6d6d4eb6a65f8e9f01ca620bc9907d79648d5038a69dd3f07b6ed3f1f"
 dependencies = [
  "byteorder",
  "combine",
  "goblin",
  "hash32",
  "libc",
- "log 0.4.14",
+ "log",
  "rand 0.7.3",
  "rustc-demangle",
  "scroll",
  "thiserror",
- "time 0.1.44",
+ "time 0.1.43",
 ]
 
 [[package]]
@@ -4928,6 +4936,22 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+
+[[package]]
+name = "spki"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "spl-associated-token-account"
@@ -4974,7 +4998,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -5004,10 +5028,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
+ "quote 1.0.16",
  "serde",
  "serde_derive",
- "syn 1.0.85",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -5018,12 +5042,12 @@ checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
+ "quote 1.0.16",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.85",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -5050,9 +5074,9 @@ dependencies = [
  "arrayref",
  "assert_matches",
  "bitvec",
- "bytes 1.1.0",
- "itertools 0.10.3",
- "sha2 0.10.1",
+ "bytes",
+ "itertools",
+ "sha2 0.10.2",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
@@ -5094,12 +5118,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
+ "quote 1.0.16",
  "unicode-xid 0.2.2",
 ]
 
@@ -5110,8 +5134,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
  "unicode-xid 0.2.2",
 ]
 
@@ -5127,9 +5151,9 @@ dependencies = [
 
 [[package]]
 name = "sysctl"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb3f7a32e17639e3705d2e05da40f485877cb97fdf0f3240e519e525e6cdb4d"
+checksum = "1123645dfaf2b5eac6b6c88addafc359c789b8ef2a770ecaef758c1ddf363ea4"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -5157,34 +5181,37 @@ dependencies = [
 
 [[package]]
 name = "tarpc"
-version = "0.24.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e325774dd5b35d979e9f4db2b0f0d7d85dc2ff2b676a3150af56c09eafc14b07"
+checksum = "b85d0a9369a919ba0db919b142a2b704cd207dfc676f7a43c2d105d0bc225487"
 dependencies = [
  "anyhow",
  "fnv",
- "futures 0.3.19",
+ "futures 0.3.21",
  "humantime",
- "log 0.4.14",
+ "opentelemetry",
  "pin-project",
- "rand 0.7.3",
+ "rand 0.8.5",
  "serde",
  "static_assertions",
  "tarpc-plugins",
+ "thiserror",
  "tokio",
  "tokio-serde",
- "tokio-util",
+ "tokio-util 0.6.9",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
 name = "tarpc-plugins"
-version = "0.9.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3240378a22b1195734e085ba71d1d4188d50f034aea82635acc430b7005afb5"
+checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -5196,16 +5223,16 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -5218,15 +5245,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "termios"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -5254,15 +5272,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.4.2+5.2.1-patched.2"
+version = "0.4.3+5.2.1-patched.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5844e429d797c62945a566f8da4e24c7fe3fbd5d6617fd8bf7a0b7dc1ee0f22e"
+checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
 dependencies = [
  "cc",
  "fs_extra",
@@ -5271,9 +5298,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
+checksum = "a5b7bcecfafe4998587d636f9ae9d55eb9d0499877b88757767c346875067098"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -5281,12 +5308,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -5301,8 +5327,18 @@ dependencies = [
  "standback",
  "stdweb",
  "time-macros",
- "version_check 0.9.4",
+ "version_check",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "libc",
+ "num_threads",
 ]
 
 [[package]]
@@ -5323,9 +5359,9 @@ checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
+ "quote 1.0.16",
  "standback",
- "syn 1.0.85",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -5364,53 +5400,22 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "libc",
  "memchr",
- "mio 0.7.14",
+ "mio 0.8.2",
  "num_cpus",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio-codec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "tokio-io",
-]
-
-[[package]]
-name = "tokio-executor"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "log 0.4.14",
 ]
 
 [[package]]
@@ -5430,8 +5435,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
@@ -5442,25 +5447,6 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-reactor"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
- "lazy_static",
- "log 0.4.14",
- "mio 0.6.23",
- "num_cpus",
- "parking_lot 0.9.0",
- "slab",
- "tokio-executor",
- "tokio-io",
- "tokio-sync",
 ]
 
 [[package]]
@@ -5476,11 +5462,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.2"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
+checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
 dependencies = [
- "rustls 0.20.2",
+ "rustls 0.20.4",
  "tokio",
  "webpki 0.22.0",
 ]
@@ -5492,7 +5478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
 dependencies = [
  "bincode",
- "bytes 1.1.0",
+ "bytes",
  "educe",
  "futures-core",
  "futures-sink",
@@ -5513,38 +5499,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-sync"
-version = "0.1.8"
+name = "tokio-tungstenite"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
+checksum = "06cda1232a49558c46f8a504d5b93101d42c0bf7f911f12a105ba48168f821ae"
 dependencies = [
- "fnv",
- "futures 0.1.31",
-]
-
-[[package]]
-name = "tokio-tcp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "iovec",
- "mio 0.6.23",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
-dependencies = [
- "futures 0.1.31",
- "native-tls",
- "tokio-io",
+ "futures-util",
+ "log",
+ "rustls 0.20.4",
+ "tokio",
+ "tokio-rustls 0.23.3",
+ "tungstenite",
+ "webpki 0.22.0",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5553,11 +5520,26 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
- "log 0.4.14",
+ "log",
+ "pin-project-lite",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64910e1b9c1901aaf5375561e35b9c057d95ff41a44ede043a03e09279eabaf1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
  "pin-project-lite",
  "tokio",
 ]
@@ -5573,20 +5555,20 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796c5e1cd49905e65dd8e700d4cb1dffcbfdb4fc9d017de08c1a537afd83627c"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
 dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.13.0",
- "bytes 1.1.0",
+ "bytes",
  "futures-core",
  "futures-util",
  "h2",
  "http",
  "http-body",
- "hyper 0.14.16",
+ "hyper",
  "hyper-timeout",
  "percent-encoding 2.1.0",
  "pin-project",
@@ -5595,7 +5577,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.22.0",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower",
  "tower-layer",
  "tower-service",
@@ -5605,32 +5587,31 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
  "proc-macro2 1.0.36",
  "prost-build",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
 name = "tower"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5651b5f6860a99bd1adb59dbfe1db8beb433e73709d9032b413a77e2fb7c066a"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.4",
+ "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.0",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5650,12 +5631,12 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if 1.0.0",
- "log 0.4.14",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5663,22 +5644,23 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -5692,19 +5674,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
+name = "tracing-opentelemetry"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+checksum = "599f388ecb26b28d9c1b2e4437ae019a7b336018b45ed911458cd9ebf91129f6"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
 
 [[package]]
 name = "trees"
-version = "0.2.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa1821e85be4f56cc5bd08bdbc32c0e26d105c90bed9c637992f6c7f747c180"
-dependencies = [
- "indexed",
-]
+checksum = "0de5f738ceab88e2491a94ddc33c3feeadfa95fedc60363ef110845df12f3878"
 
 [[package]]
 name = "try-lock"
@@ -5714,29 +5710,25 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.10.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
+checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.13.0",
  "byteorder",
- "bytes 0.5.6",
+ "bytes",
  "http",
  "httparse",
- "input_buffer",
- "log 0.4.14",
- "native-tls",
- "rand 0.7.3",
- "sha-1 0.8.2",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.20.4",
+ "sha-1 0.10.0",
+ "thiserror",
  "url 2.2.2",
  "utf-8",
+ "webpki 0.22.0",
+ "webpki-roots",
 ]
-
-[[package]]
-name = "typeable"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
@@ -5752,20 +5744,11 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-dependencies = [
- "version_check 0.1.5",
-]
-
-[[package]]
-name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -5785,9 +5768,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -5806,6 +5789,16 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "universal-hash"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+dependencies = [
+ "generic-array 0.14.5",
+ "subtle",
+]
 
 [[package]]
 name = "unix_socket2"
@@ -5833,9 +5826,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "uriparse"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e515b1ada404168e145ac55afba3c42f04cf972201a8552d42e2abb17c1b7221"
+checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
 dependencies = [
  "fnv",
  "lazy_static",
@@ -5871,7 +5864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
 dependencies = [
  "libc",
- "log 0.4.14",
+ "log",
 ]
 
 [[package]]
@@ -5886,8 +5879,14 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.5",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -5900,12 +5899,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -5936,7 +5929,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.14",
+ "log",
  "try-lock",
 ]
 
@@ -5948,15 +5941,21 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -5964,24 +5963,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -5991,38 +5990,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
- "quote 1.0.14",
+ "quote 1.0.16",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6058,51 +6057,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "websocket"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413b37840b9e27b340ce91b319ede10731de8c72f5bc4cb0206ec1ca4ce581d0"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "hyper 0.10.16",
- "native-tls",
- "rand 0.6.5",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
- "tokio-tcp",
- "tokio-tls",
- "unicase 1.4.2",
- "url 1.7.2",
- "websocket-base",
-]
-
-[[package]]
-name = "websocket-base"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3810f0d00c4dccb54c30a4eee815e703232819dec7b007db115791c42aa374"
-dependencies = [
- "base64 0.10.1",
- "bitflags",
- "byteorder",
- "bytes 0.4.12",
- "futures 0.1.31",
- "native-tls",
- "rand 0.6.5",
- "sha1",
- "tokio-codec",
- "tokio-io",
- "tokio-tcp",
- "tokio-tls",
-]
-
-[[package]]
 name = "which"
-version = "4.2.2"
+version = "4.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
 dependencies = [
  "either",
  "lazy_static",
@@ -6153,22 +6111,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "winreg"
-version = "0.7.0"
+name = "windows-sys"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+checksum = "030b7ff91626e57a05ca64a07c481973cbb2db774e4852c9c7ca342408c6a99a"
 dependencies = [
- "winapi 0.3.9",
+ "windows_aarch64_msvc 0.30.0",
+ "windows_i686_gnu 0.30.0",
+ "windows_i686_msvc 0.30.0",
+ "windows_x86_64_gnu 0.30.0",
+ "windows_x86_64_msvc 0.30.0",
 ]
 
 [[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
+name = "windows-sys"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
 dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6199,40 +6233,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.4.3"
+name = "yasna"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
+dependencies = [
+ "time 0.3.9",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.2"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2 1.0.36",
- "quote 1.0.14",
- "syn 1.0.85",
+ "quote 1.0.16",
+ "syn 1.0.89",
  "synstructure",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.5.4+zstd.1.4.7"
+version = "0.11.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69996ebdb1ba8b1517f61387a883857818a66c8a295f487b1ffd8fd9d2c82910"
+checksum = "77a16b8414fde0414e90c612eba70985577451c4c504b99885ebed24762cb81a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "2.0.6+zstd.1.4.7"
+version = "5.0.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98aa931fb69ecee256d44589d19754e61851ae4769bf963b385119b1cc37a49e"
+checksum = "7c12659121420dd6365c5c3de4901f97145b79651fb1d25814020ed2ed0585ae"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -6240,12 +6283,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.18+zstd.1.4.7"
+version = "2.0.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6e8778706838f43f771d80d37787cb2fe06dafe89dd3aebaf6721b9eaec81"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
- "glob",
- "itertools 0.9.0",
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "strike-wallet"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 publish = false
 resolver = "2"
 
@@ -10,7 +10,7 @@ bytes = "1.1.0"
 arrayref = "0.3.6"
 bitvec = "1.0"
 itertools = "0.10.3"
-solana-program = "=1.8.14"
+solana-program = "=1.10.3"
 spl-associated-token-account = { version = "=1.0.3", features = ["no-entrypoint"] }
 spl-token = "=3.2.0"
 thiserror = "1.0.30"
@@ -21,10 +21,10 @@ no-entrypoint = []
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-sha2 = "0.10.1"
-solana-program-test = "=1.8.14"
-solana-sdk = "=1.8.14"
-solana-validator = "=1.8.14"
+sha2 = "0.10.2"
+solana-program-test = "=1.10.3"
+solana-sdk = "=1.10.3"
+solana-validator = "=1.10.3"
 uuid = { version = "0.8.2", features = ["v4"] }
 
 [lib]

--- a/src/handlers/address_book_update_handler.rs
+++ b/src/handlers/address_book_update_handler.rs
@@ -1,6 +1,6 @@
 use crate::handlers::utils::{
     finalize_multisig_op, get_clock_from_next_account, next_program_account_info,
-    start_multisig_config_op,
+    start_multisig_config_op, validate_wallet_account,
 };
 use crate::instruction::AddressBookUpdate;
 use crate::model::multisig_op::MultisigOpParams;
@@ -13,6 +13,7 @@ use solana_program::pubkey::Pubkey;
 pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     update: &AddressBookUpdate,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
@@ -20,6 +21,12 @@ pub fn init(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let initiator_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
     wallet.validate_config_initiator(initiator_account_info)?;
@@ -40,6 +47,7 @@ pub fn init(
 pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     update: &AddressBookUpdate,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
@@ -47,6 +55,12 @@ pub fn finalize(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let account_to_return_rent_to = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     finalize_multisig_op(
         &multisig_op_account_info,

--- a/src/handlers/address_book_update_handler.rs
+++ b/src/handlers/address_book_update_handler.rs
@@ -23,9 +23,10 @@ pub fn init(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
@@ -57,9 +58,10 @@ pub fn finalize(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     finalize_multisig_op(

--- a/src/handlers/balance_account_creation_handler.rs
+++ b/src/handlers/balance_account_creation_handler.rs
@@ -25,9 +25,10 @@ pub fn init(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
@@ -61,9 +62,10 @@ pub fn finalize(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     finalize_multisig_op(

--- a/src/handlers/balance_account_creation_handler.rs
+++ b/src/handlers/balance_account_creation_handler.rs
@@ -1,6 +1,6 @@
 use crate::handlers::utils::{
     finalize_multisig_op, get_clock_from_next_account, next_program_account_info,
-    start_multisig_config_op,
+    start_multisig_config_op, validate_wallet_account,
 };
 use crate::instruction::BalanceAccountCreation;
 use crate::model::balance_account::BalanceAccountGuidHash;
@@ -14,6 +14,7 @@ use solana_program::pubkey::Pubkey;
 pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     account_guid_hash: &BalanceAccountGuidHash,
     creation_params: &BalanceAccountCreation,
 ) -> ProgramResult {
@@ -22,6 +23,12 @@ pub fn init(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let initiator_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
     wallet.validate_config_initiator(initiator_account_info)?;
@@ -43,6 +50,7 @@ pub fn init(
 pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     account_guid_hash: &BalanceAccountGuidHash,
     creation_params: &BalanceAccountCreation,
 ) -> ProgramResult {
@@ -51,6 +59,12 @@ pub fn finalize(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let rent_collector_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     finalize_multisig_op(
         &multisig_op_account_info,

--- a/src/handlers/balance_account_name_update_handler.rs
+++ b/src/handlers/balance_account_name_update_handler.rs
@@ -1,6 +1,6 @@
 use crate::handlers::utils::{
     finalize_multisig_op, get_clock_from_next_account, next_program_account_info,
-    start_multisig_config_op,
+    start_multisig_config_op, validate_wallet_account,
 };
 use crate::model::balance_account::{BalanceAccountGuidHash, BalanceAccountNameHash};
 use crate::model::multisig_op::MultisigOpParams;
@@ -13,6 +13,7 @@ use solana_program::pubkey::Pubkey;
 pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     account_guid_hash: &BalanceAccountGuidHash,
     account_name_hash: &BalanceAccountNameHash,
 ) -> ProgramResult {
@@ -21,6 +22,12 @@ pub fn init(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let initiator_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let wallet: Wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
 
@@ -48,6 +55,7 @@ pub fn init(
 pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     account_guid_hash: &BalanceAccountGuidHash,
     account_name_hash: &BalanceAccountNameHash,
 ) -> ProgramResult {
@@ -56,6 +64,12 @@ pub fn finalize(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let account_to_return_rent_to = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     finalize_multisig_op(
         &multisig_op_account_info,

--- a/src/handlers/balance_account_name_update_handler.rs
+++ b/src/handlers/balance_account_name_update_handler.rs
@@ -24,9 +24,10 @@ pub fn init(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let wallet: Wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
@@ -66,9 +67,10 @@ pub fn finalize(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     finalize_multisig_op(

--- a/src/handlers/balance_account_policy_update_handler.rs
+++ b/src/handlers/balance_account_policy_update_handler.rs
@@ -1,6 +1,6 @@
 use crate::handlers::utils::{
     finalize_multisig_op, get_clock_from_next_account, next_program_account_info,
-    start_multisig_config_op,
+    start_multisig_config_op, validate_wallet_account,
 };
 use crate::instruction::BalanceAccountPolicyUpdate;
 use crate::model::balance_account::BalanceAccountGuidHash;
@@ -14,6 +14,7 @@ use solana_program::pubkey::Pubkey;
 pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     account_guid_hash: &BalanceAccountGuidHash,
     update: &BalanceAccountPolicyUpdate,
 ) -> ProgramResult {
@@ -22,6 +23,12 @@ pub fn init(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let initiator_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
     wallet.validate_config_initiator(initiator_account_info)?;
@@ -48,6 +55,7 @@ pub fn init(
 pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     account_guid_hash: &BalanceAccountGuidHash,
     update: &BalanceAccountPolicyUpdate,
 ) -> ProgramResult {
@@ -56,6 +64,12 @@ pub fn finalize(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let rent_collector_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow_mut())?;
 

--- a/src/handlers/balance_account_policy_update_handler.rs
+++ b/src/handlers/balance_account_policy_update_handler.rs
@@ -25,9 +25,10 @@ pub fn init(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
@@ -66,9 +67,10 @@ pub fn finalize(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow_mut())?;

--- a/src/handlers/balance_account_settings_update_handler.rs
+++ b/src/handlers/balance_account_settings_update_handler.rs
@@ -25,9 +25,10 @@ pub fn init(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
@@ -65,9 +66,10 @@ pub fn finalize(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     finalize_multisig_op(

--- a/src/handlers/balance_account_settings_update_handler.rs
+++ b/src/handlers/balance_account_settings_update_handler.rs
@@ -1,6 +1,6 @@
 use crate::handlers::utils::{
     finalize_multisig_op, get_clock_from_next_account, next_program_account_info,
-    start_multisig_config_op,
+    start_multisig_config_op, validate_wallet_account,
 };
 use crate::model::balance_account::BalanceAccountGuidHash;
 use crate::model::multisig_op::{BooleanSetting, MultisigOpParams};
@@ -13,6 +13,7 @@ use solana_program::pubkey::Pubkey;
 pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     account_guid_hash: &BalanceAccountGuidHash,
     whitelist_enabled: Option<BooleanSetting>,
     dapps_enabled: Option<BooleanSetting>,
@@ -22,6 +23,12 @@ pub fn init(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let initiator_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
     wallet.validate_config_initiator(initiator_account_info)?;
@@ -46,6 +53,7 @@ pub fn init(
 pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     account_guid_hash: &BalanceAccountGuidHash,
     whitelist_enabled: Option<BooleanSetting>,
     dapps_enabled: Option<BooleanSetting>,
@@ -55,6 +63,12 @@ pub fn finalize(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let account_to_return_rent_to = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     finalize_multisig_op(
         &multisig_op_account_info,

--- a/src/handlers/dapp_book_update_handler.rs
+++ b/src/handlers/dapp_book_update_handler.rs
@@ -1,6 +1,6 @@
 use crate::handlers::utils::{
     finalize_multisig_op, get_clock_from_next_account, next_program_account_info,
-    start_multisig_config_op,
+    start_multisig_config_op, validate_wallet_account,
 };
 use crate::instruction::DAppBookUpdate;
 use crate::model::multisig_op::MultisigOpParams;
@@ -13,6 +13,7 @@ use solana_program::pubkey::Pubkey;
 pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     update: &DAppBookUpdate,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
@@ -20,6 +21,12 @@ pub fn init(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let initiator_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
 
@@ -45,6 +52,7 @@ pub fn init(
 pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     update: &DAppBookUpdate,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
@@ -52,6 +60,12 @@ pub fn finalize(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let account_to_return_rent_to = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow_mut())?;
 

--- a/src/handlers/dapp_book_update_handler.rs
+++ b/src/handlers/dapp_book_update_handler.rs
@@ -23,9 +23,10 @@ pub fn init(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
@@ -62,9 +63,10 @@ pub fn finalize(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow_mut())?;

--- a/src/handlers/dapp_transaction_handler.rs
+++ b/src/handlers/dapp_transaction_handler.rs
@@ -38,9 +38,10 @@ pub fn init(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
@@ -267,9 +268,10 @@ pub fn finalize(
     }
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     if MultisigOp::version_from_slice(&multisig_op_account_info.data.borrow())? == VERSION {

--- a/src/handlers/init_wallet_handler.rs
+++ b/src/handlers/init_wallet_handler.rs
@@ -26,9 +26,10 @@ pub fn handle(
     let fee_payer_account_info = next_account_info(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        false,
     )?;
 
     let rent = Rent::get()?;

--- a/src/handlers/init_wallet_handler.rs
+++ b/src/handlers/init_wallet_handler.rs
@@ -1,21 +1,53 @@
-use crate::handlers::utils::next_program_account_info;
-use crate::instruction::InitialWalletConfig;
-use crate::model::signer::Signer;
-use crate::model::wallet::Wallet;
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
+use solana_program::program::invoke_signed;
 use solana_program::program_error::ProgramError;
 use solana_program::program_pack::{IsInitialized, Pack};
 use solana_program::pubkey::Pubkey;
+use solana_program::rent::Rent;
+use solana_program::system_instruction;
+use solana_program::sysvar::Sysvar;
+
+use crate::handlers::utils::validate_wallet_account;
+use crate::instruction::InitialWalletConfig;
+use crate::model::signer::Signer;
+use crate::model::wallet::Wallet;
+use crate::version::VERSION;
 
 pub fn handle(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     update: &InitialWalletConfig,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
-    let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
+    let wallet_account_info = next_account_info(accounts_iter)?;
     let assistant_account_info = next_account_info(accounts_iter)?;
+    let fee_payer_account_info = next_account_info(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
+
+    let rent = Rent::get()?;
+    let wallet_account_rent = rent.minimum_balance(Wallet::LEN);
+    invoke_signed(
+        &system_instruction::create_account(
+            fee_payer_account_info.key,
+            &wallet_account_info.key,
+            wallet_account_rent,
+            Wallet::LEN as u64,
+            program_id,
+        ),
+        &[fee_payer_account_info.clone(), wallet_account_info.clone()],
+        &[&[
+            b"version",
+            &VERSION.to_le_bytes(),
+            &[wallet_account_bump_seed],
+        ]],
+    )?;
 
     let mut wallet = Wallet::unpack_unchecked(&wallet_account_info.data.borrow())?;
 
@@ -27,6 +59,7 @@ pub fn handle(
     wallet.assistant = Signer {
         key: *assistant_account_info.key,
     };
+    wallet.rent_return_address = *fee_payer_account_info.key;
     wallet.initialize(update)?;
     Wallet::pack(wallet, &mut wallet_account_info.data.borrow_mut())?;
 

--- a/src/handlers/spl_token_accounts_creation_handler.rs
+++ b/src/handlers/spl_token_accounts_creation_handler.rs
@@ -1,3 +1,4 @@
+use crate::handlers::utils::validate_wallet_account;
 use crate::{
     error::WalletError,
     handlers::utils::{
@@ -33,6 +34,7 @@ pub const MAX_BALANCE_ACCOUNT_GUID_HASHES: usize = 5;
 pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     payer_account_guid_hash: &BalanceAccountGuidHash,
     account_guid_hashes: &Vec<BalanceAccountGuidHash>,
 ) -> ProgramResult {
@@ -43,6 +45,12 @@ pub fn init(
     let initiator_account_info = next_account_info(accounts_iter)?;
     let token_mint_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let wallet: Wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
 
@@ -118,6 +126,7 @@ pub fn init(
 pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     payer_account_guid_hash: &BalanceAccountGuidHash,
     account_guid_hashes: &Vec<BalanceAccountGuidHash>,
 ) -> ProgramResult {
@@ -137,6 +146,12 @@ pub fn finalize(
     let _spl_associated_token_account_info = next_account_info(accounts_iter)?;
     let spl_token_program_account_info = next_account_info(accounts_iter)?;
     let rent_account_info = next_account_info(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     if *system_program_account_info.key != system_program::id() {
         msg!("Instruction expected system program account");

--- a/src/handlers/spl_token_accounts_creation_handler.rs
+++ b/src/handlers/spl_token_accounts_creation_handler.rs
@@ -47,9 +47,10 @@ pub fn init(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let wallet: Wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
@@ -148,9 +149,10 @@ pub fn finalize(
     let rent_account_info = next_account_info(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     if *system_program_account_info.key != system_program::id() {

--- a/src/handlers/transfer_handler.rs
+++ b/src/handlers/transfer_handler.rs
@@ -3,7 +3,7 @@ use crate::error::WalletError;
 use crate::handlers::utils::{
     create_associated_token_account_instruction, finalize_multisig_op, get_clock_from_next_account,
     next_program_account_info, start_multisig_transfer_op, transfer_sol_checked,
-    validate_balance_account_and_get_seed,
+    validate_balance_account_and_get_seed, validate_wallet_account,
 };
 use crate::model::address_book::AddressBookEntryNameHash;
 use crate::model::balance_account::BalanceAccountGuidHash;
@@ -27,6 +27,7 @@ use spl_token::state::Account as SPLAccount;
 pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     account_guid_hash: &BalanceAccountGuidHash,
     amount: u64,
     destination_name_hash: &AddressBookEntryNameHash,
@@ -41,6 +42,12 @@ pub fn init(
     let token_mint = next_account_info(accounts_iter)?;
     let destination_token_account = next_account_info(accounts_iter)?;
     let fee_payer_account = next_account_info(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
     let balance_account = wallet.get_balance_account(account_guid_hash)?;
@@ -125,6 +132,7 @@ pub fn init(
 pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     account_guid_hash: &BalanceAccountGuidHash,
     amount: u64,
     token_mint: Pubkey,
@@ -143,6 +151,12 @@ pub fn finalize(
     if system_program_account.key != &system_program::id() {
         return Err(WalletError::AccountNotRecognized.into());
     }
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     finalize_multisig_op(
         &multisig_op_account_info,

--- a/src/handlers/transfer_handler.rs
+++ b/src/handlers/transfer_handler.rs
@@ -44,9 +44,10 @@ pub fn init(
     let fee_payer_account = next_account_info(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
@@ -153,9 +154,10 @@ pub fn finalize(
     }
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     finalize_multisig_op(

--- a/src/handlers/update_signer_handler.rs
+++ b/src/handlers/update_signer_handler.rs
@@ -1,6 +1,6 @@
 use crate::handlers::utils::{
     finalize_multisig_op, get_clock_from_next_account, next_program_account_info,
-    start_multisig_config_op,
+    start_multisig_config_op, validate_wallet_account,
 };
 use crate::model::multisig_op::{MultisigOpParams, SlotUpdateType};
 use crate::model::signer::Signer;
@@ -14,6 +14,7 @@ use solana_program::pubkey::Pubkey;
 pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     slot_update_type: SlotUpdateType,
     slot_id: SlotId<Signer>,
     signer: Signer,
@@ -23,6 +24,12 @@ pub fn init(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let initiator_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
     wallet.validate_config_initiator(initiator_account_info)?;
@@ -48,6 +55,7 @@ pub fn init(
 pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     slot_update_type: SlotUpdateType,
     slot_id: SlotId<Signer>,
     signer: Signer,
@@ -57,6 +65,12 @@ pub fn finalize(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let account_to_return_rent_to = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     finalize_multisig_op(
         &multisig_op_account_info,

--- a/src/handlers/update_signer_handler.rs
+++ b/src/handlers/update_signer_handler.rs
@@ -26,9 +26,10 @@ pub fn init(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
@@ -67,9 +68,10 @@ pub fn finalize(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     finalize_multisig_op(

--- a/src/handlers/wallet_config_policy_update_handler.rs
+++ b/src/handlers/wallet_config_policy_update_handler.rs
@@ -1,6 +1,6 @@
 use crate::handlers::utils::{
     finalize_multisig_op, get_clock_from_next_account, next_program_account_info,
-    start_multisig_config_op,
+    start_multisig_config_op, validate_wallet_account,
 };
 use crate::instruction::WalletConfigPolicyUpdate;
 use crate::model::multisig_op::MultisigOpParams;
@@ -13,6 +13,7 @@ use solana_program::pubkey::Pubkey;
 pub fn init(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     update: &WalletConfigPolicyUpdate,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
@@ -20,6 +21,12 @@ pub fn init(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let initiator_account_info = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
 
@@ -46,6 +53,7 @@ pub fn init(
 pub fn finalize(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
+    wallet_account_bump_seed: u8,
     update: &WalletConfigPolicyUpdate,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
@@ -53,6 +61,12 @@ pub fn finalize(
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
     let account_to_return_rent_to = next_account_info(accounts_iter)?;
     let clock = get_clock_from_next_account(accounts_iter)?;
+
+    validate_wallet_account(
+        wallet_account_info.key,
+        wallet_account_bump_seed,
+        program_id,
+    )?;
 
     let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow_mut())?;
 

--- a/src/handlers/wallet_config_policy_update_handler.rs
+++ b/src/handlers/wallet_config_policy_update_handler.rs
@@ -23,9 +23,10 @@ pub fn init(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
@@ -63,9 +64,10 @@ pub fn finalize(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow_mut())?;

--- a/src/handlers/wrap_unwrap_handler.rs
+++ b/src/handlers/wrap_unwrap_handler.rs
@@ -41,9 +41,10 @@ pub fn init(
     let clock = get_clock_from_next_account(accounts_iter)?;
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
@@ -110,9 +111,10 @@ pub fn finalize(
     }
 
     validate_wallet_account(
-        wallet_account_info.key,
+        wallet_account_info,
         wallet_account_bump_seed,
         program_id,
+        true,
     )?;
 
     finalize_multisig_op(

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -62,13 +62,19 @@ pub const TAG_FINALIZE_BALANCE_ACCOUNT_ENABLE_SPL_TOKEN: u8 = 30;
 pub enum ProgramInstruction {
     /// 0. `[writable]` The wallet account
     /// 1. `[signer]` The transaction assistant account
-    InitWallet { initial_config: InitialWalletConfig },
+    /// 2. `[signer]` The fee payer account
+    /// 3. `[]` The system program
+    InitWallet {
+        wallet_account_bump_seed: u8,
+        initial_config: InitialWalletConfig,
+    },
 
     /// 0. `[writable]` The multisig operation account
     /// 1. `[]` The wallet account
     /// 2. `[signer]` The initiator account (either the transaction assistant or an approver)
     /// 3. `[]` The sysvar clock account
     InitBalanceAccountCreation {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         creation_params: BalanceAccountCreation,
     },
@@ -77,6 +83,7 @@ pub enum ProgramInstruction {
     /// 1. `[writable]` The wallet account
     /// 2. `[signer]` The rent collector account
     FinalizeBalanceAccountCreation {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         creation_params: BalanceAccountCreation,
     },
@@ -97,6 +104,7 @@ pub enum ProgramInstruction {
     /// 11. `[]` The Rent sysvar program (only used for SPL transfers)
     /// 12. `[]` The SPL associated token program (only used for SPL transfers)
     InitTransfer {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         amount: u64,
         destination_name_hash: AddressBookEntryNameHash,
@@ -122,6 +130,7 @@ pub enum ProgramInstruction {
     /// 9. `[]` The SPL token program account, if this is an SPL transfer
     /// 10. `[]` The token mint authority, if this is an SPL transfer
     FinalizeTransfer {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         amount: u64,
         token_mint: Pubkey,
@@ -139,6 +148,7 @@ pub enum ProgramInstruction {
     /// 9. `[]` The Rent sysvar program
     /// 10. `[]` The SPL associated token program
     InitWrapUnwrap {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         amount: u64,
         direction: WrapDirection,
@@ -153,6 +163,7 @@ pub enum ProgramInstruction {
     /// 6. `[writable]` The wrapped SOL token account
     /// 7. `[]` The SPL token account
     FinalizeWrapUnwrap {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         amount: u64,
         direction: WrapDirection,
@@ -162,6 +173,7 @@ pub enum ProgramInstruction {
     /// 2. `[signer]` The initiator account (either the transaction assistant or an approver)
     /// 3. `[]` The sysvar clock account
     InitUpdateSigner {
+        wallet_account_bump_seed: u8,
         slot_update_type: SlotUpdateType,
         slot_id: SlotId<Signer>,
         signer: Signer,
@@ -171,6 +183,7 @@ pub enum ProgramInstruction {
     /// 1. `[writable]` The wallet account
     /// 2. `[signer]` The rent collector account
     FinalizeUpdateSigner {
+        wallet_account_bump_seed: u8,
         slot_update_type: SlotUpdateType,
         slot_id: SlotId<Signer>,
         signer: Signer,
@@ -180,12 +193,17 @@ pub enum ProgramInstruction {
     /// 1. `[writable]` The wallet account
     /// 2. `[signer]` The initiator account (either the transaction assistant or an approver)
     /// 3. `[]` The sysvar clock account
-    InitWalletConfigPolicyUpdate { update: WalletConfigPolicyUpdate },
-
+    InitWalletConfigPolicyUpdate {
+        wallet_account_bump_seed: u8,
+        update: WalletConfigPolicyUpdate,
+    },
     /// 0  `[writable]` The multisig operation account
     /// 1. `[writable]` The wallet account
     /// 2. `[signer]` The rent collector account
-    FinalizeWalletConfigPolicyUpdate { update: WalletConfigPolicyUpdate },
+    FinalizeWalletConfigPolicyUpdate {
+        wallet_account_bump_seed: u8,
+        update: WalletConfigPolicyUpdate,
+    },
 
     /// 0. `[writable]` The multisig operation account
     /// 1. `[writable]` The multisig data account
@@ -193,6 +211,7 @@ pub enum ProgramInstruction {
     /// 3. `[signer]` The initiator account (either the transaction assistant or an approver)
     /// 4. `[]` The sysvar clock account
     InitDAppTransaction {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         dapp: DAppBookEntry,
         instruction_count: u8,
@@ -213,6 +232,7 @@ pub enum ProgramInstruction {
     /// 4. `[signer]` The rent collector account
     /// 5. `[]` The sysvar clock account
     FinalizeDAppTransaction {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         params_hash: Hash,
     },
@@ -222,6 +242,7 @@ pub enum ProgramInstruction {
     /// 2. `[signer]` The initiator account (either the transaction assistant or an approver)
     /// 3. `[]` The sysvar clock account
     InitAccountSettingsUpdate {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         whitelist_enabled: Option<BooleanSetting>,
         dapps_enabled: Option<BooleanSetting>,
@@ -231,6 +252,7 @@ pub enum ProgramInstruction {
     /// 1. `[writable]` The wallet account
     /// 2. `[signer]` The rent collector account
     FinalizeAccountSettingsUpdate {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         whitelist_enabled: Option<BooleanSetting>,
         dapps_enabled: Option<BooleanSetting>,
@@ -240,31 +262,44 @@ pub enum ProgramInstruction {
     /// 1. `[]` The wallet account
     /// 2. `[signer]` The initiator account (either the transaction assistant or an approver)
     /// 3. `[]` The sysvar clock account
-    InitDAppBookUpdate { update: DAppBookUpdate },
+    InitDAppBookUpdate {
+        wallet_account_bump_seed: u8,
+        update: DAppBookUpdate,
+    },
 
     /// 0. `[writable]` The multisig operation account
     /// 1. `[writable]` The wallet account
     /// 2. `[signer]` The rent collector account
     /// 3. `[]` The sysvar clock account
-    FinalizeDAppBookUpdate { update: DAppBookUpdate },
+    FinalizeDAppBookUpdate {
+        wallet_account_bump_seed: u8,
+        update: DAppBookUpdate,
+    },
 
     /// 0. `[writable]` The multisig operation account
     /// 1. `[]` The wallet account
     /// 2. `[signer]` The initiator account (either the transaction assistant or an approver)
     /// 3. `[]` The sysvar clock account
-    InitAddressBookUpdate { update: AddressBookUpdate },
+    InitAddressBookUpdate {
+        wallet_account_bump_seed: u8,
+        update: AddressBookUpdate,
+    },
 
     /// 0. `[writable]` The multisig operation account
     /// 1. `[writable]` The wallet account
     /// 2. `[signer]` The rent collector account
     /// 3. `[]` The sysvar clock account
-    FinalizeAddressBookUpdate { update: AddressBookUpdate },
+    FinalizeAddressBookUpdate {
+        wallet_account_bump_seed: u8,
+        update: AddressBookUpdate,
+    },
 
     /// 0. `[writable]` The multisig operation account
     /// 1. `[]` The wallet account
     /// 2. `[signer]` The initiator account (either the transaction assistant or an approver)
     /// 3. `[]` The sysvar clock account
     InitBalanceAccountNameUpdate {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         account_name_hash: BalanceAccountNameHash,
     },
@@ -274,6 +309,7 @@ pub enum ProgramInstruction {
     /// 2. `[signer]` The rent collector account
     /// 3. `[]` The sysvar clock account
     FinalizeBalanceAccountNameUpdate {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         account_name_hash: BalanceAccountNameHash,
     },
@@ -283,6 +319,7 @@ pub enum ProgramInstruction {
     /// 2. `[signer]` The initiator account (either the transaction assistant or an approver)
     /// 3. `[]` The sysvar clock account
     InitBalanceAccountPolicyUpdate {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         update: BalanceAccountPolicyUpdate,
     },
@@ -292,6 +329,7 @@ pub enum ProgramInstruction {
     /// 2. `[signer]` The rent collector account
     /// 3. `[]` The sysvar clock account
     FinalizeBalanceAccountPolicyUpdate {
+        wallet_account_bump_seed: u8,
         account_guid_hash: BalanceAccountGuidHash,
         update: BalanceAccountPolicyUpdate,
     },
@@ -304,6 +342,7 @@ pub enum ProgramInstruction {
     /// 5..N `[]` One or more associated token accounts, corresponding in number
     ///           and order to the account GUID hashes.
     InitSPLTokenAccountsCreation {
+        wallet_account_bump_seed: u8,
         payer_account_guid_hash: BalanceAccountGuidHash,
         account_guid_hashes: Vec<BalanceAccountGuidHash>,
     },
@@ -322,6 +361,7 @@ pub enum ProgramInstruction {
     /// N..M  `[]` One or more BalanceAccount accounts, corresponding in number
     ///            and order to the associated token accounts.
     FinalizeSPLTokenAccountsCreation {
+        wallet_account_bump_seed: u8,
         payer_account_guid_hash: BalanceAccountGuidHash,
         account_guid_hashes: Vec<BalanceAccountGuidHash>,
     },
@@ -333,49 +373,59 @@ impl ProgramInstruction {
         let mut buf = Vec::with_capacity(size_of::<Self>());
         match self {
             &ProgramInstruction::InitWallet {
+                wallet_account_bump_seed,
                 initial_config: ref update,
             } => {
                 let mut update_bytes: Vec<u8> = Vec::new();
                 update.pack(&mut update_bytes);
                 buf.push(TAG_INIT_WALLET);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(&update_bytes);
             }
             &ProgramInstruction::InitBalanceAccountCreation {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref creation_params,
             } => {
                 let mut update_bytes: Vec<u8> = Vec::new();
                 creation_params.pack(&mut update_bytes);
                 buf.push(TAG_INIT_BALANCE_ACCOUNT_CREATION);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(account_guid_hash.to_bytes());
                 buf.extend_from_slice(&update_bytes);
             }
             &ProgramInstruction::FinalizeBalanceAccountCreation {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref creation_params,
             } => {
                 let mut update_bytes: Vec<u8> = Vec::new();
                 creation_params.pack(&mut update_bytes);
                 buf.push(TAG_FINALIZE_BALANCE_ACCOUNT_CREATION);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(account_guid_hash.to_bytes());
                 buf.extend_from_slice(&update_bytes);
             }
             &ProgramInstruction::InitTransfer {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref amount,
                 ref destination_name_hash,
             } => {
                 buf.push(TAG_INIT_TRANSFER);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(account_guid_hash.to_bytes());
                 buf.extend_from_slice(&amount.to_le_bytes());
                 buf.extend_from_slice(destination_name_hash.to_bytes());
             }
             &ProgramInstruction::FinalizeTransfer {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref amount,
                 ref token_mint,
             } => {
                 buf.push(TAG_FINALIZE_TRANSFER);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(account_guid_hash.to_bytes());
                 buf.extend_from_slice(&amount.to_le_bytes());
                 buf.extend_from_slice(&token_mint.to_bytes());
@@ -390,63 +440,81 @@ impl ProgramInstruction {
                 buf.extend_from_slice(params_hash.as_ref());
             }
             &ProgramInstruction::InitWrapUnwrap {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref amount,
                 ref direction,
             } => {
                 buf.push(TAG_INIT_WRAP_UNWRAP);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
                 buf.extend_from_slice(&amount.to_le_bytes());
                 buf.push(direction.to_u8());
             }
             &ProgramInstruction::FinalizeWrapUnwrap {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref amount,
                 ref direction,
             } => {
                 buf.push(TAG_FINALIZE_WRAP_UNWRAP);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
                 buf.extend_from_slice(&amount.to_le_bytes());
                 buf.push(direction.to_u8());
             }
             &ProgramInstruction::InitUpdateSigner {
+                wallet_account_bump_seed,
                 ref slot_update_type,
                 ref slot_id,
                 ref signer,
             } => {
                 buf.push(TAG_INIT_UPDATE_SIGNER);
+                buf.push(wallet_account_bump_seed);
                 buf.push(slot_update_type.to_u8());
                 buf.push(slot_id.value as u8);
                 buf.extend_from_slice(signer.key.as_ref());
             }
             &ProgramInstruction::FinalizeUpdateSigner {
+                wallet_account_bump_seed,
                 ref slot_update_type,
                 ref slot_id,
                 ref signer,
             } => {
                 buf.push(TAG_FINALIZE_UPDATE_SIGNER);
+                buf.push(wallet_account_bump_seed);
                 buf.push(slot_update_type.to_u8());
                 buf.push(slot_id.value as u8);
                 buf.extend_from_slice(signer.key.as_ref());
             }
-            &ProgramInstruction::InitWalletConfigPolicyUpdate { ref update } => {
+            &ProgramInstruction::InitWalletConfigPolicyUpdate {
+                wallet_account_bump_seed,
+                ref update,
+            } => {
                 let mut update_bytes: Vec<u8> = Vec::new();
                 update.pack(&mut update_bytes);
                 buf.push(TAG_INIT_WALLET_CONFIG_POLICY_UPDATE);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(&update_bytes);
             }
-            &ProgramInstruction::FinalizeWalletConfigPolicyUpdate { ref update } => {
+            &ProgramInstruction::FinalizeWalletConfigPolicyUpdate {
+                wallet_account_bump_seed,
+                ref update,
+            } => {
                 let mut update_bytes: Vec<u8> = Vec::new();
                 update.pack(&mut update_bytes);
                 buf.push(TAG_FINALIZE_WALLET_CONFIG_POLICY_UPDATE);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(&update_bytes);
             }
             &ProgramInstruction::InitDAppTransaction {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref dapp,
                 instruction_count,
             } => {
                 buf.push(TAG_INIT_DAPP_TRANSACTION);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
                 let mut buf2 = vec![0; DAppBookEntry::LEN];
                 dapp.pack_into_slice(buf2.as_mut_slice());
@@ -454,90 +522,120 @@ impl ProgramInstruction {
                 buf.put_u8(instruction_count);
             }
             &ProgramInstruction::FinalizeDAppTransaction {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref params_hash,
             } => {
                 buf.push(TAG_FINALIZE_DAPP_TRANSACTION);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
                 buf.extend_from_slice(&params_hash.to_bytes());
             }
             &ProgramInstruction::InitAccountSettingsUpdate {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref whitelist_enabled,
                 ref dapps_enabled,
             } => {
                 buf.push(TAG_INIT_ACCOUNT_SETTINGS_UPDATE);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
                 pack_option(whitelist_enabled.as_ref(), &mut buf);
                 pack_option(dapps_enabled.as_ref(), &mut buf);
             }
             &ProgramInstruction::FinalizeAccountSettingsUpdate {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref whitelist_enabled,
                 ref dapps_enabled,
             } => {
                 buf.push(TAG_FINALIZE_ACCOUNT_SETTINGS_UPDATE);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(&account_guid_hash.to_bytes());
                 pack_option(whitelist_enabled.as_ref(), &mut buf);
                 pack_option(dapps_enabled.as_ref(), &mut buf);
             }
-            &ProgramInstruction::InitDAppBookUpdate { ref update } => {
+            &ProgramInstruction::InitDAppBookUpdate {
+                wallet_account_bump_seed,
+                ref update,
+            } => {
                 buf.push(TAG_INIT_DAPP_BOOK_UPDATE);
+                buf.push(wallet_account_bump_seed);
                 let mut update_bytes: Vec<u8> = Vec::new();
                 update.pack(&mut update_bytes);
                 buf.extend_from_slice(&update_bytes);
             }
-            &ProgramInstruction::FinalizeDAppBookUpdate { ref update } => {
+            &ProgramInstruction::FinalizeDAppBookUpdate {
+                wallet_account_bump_seed,
+                ref update,
+            } => {
                 buf.push(TAG_FINALIZE_DAPP_BOOK_UPDATE);
+                buf.push(wallet_account_bump_seed);
                 let mut update_bytes: Vec<u8> = Vec::new();
                 update.pack(&mut update_bytes);
                 buf.extend_from_slice(&update_bytes);
             }
-            &ProgramInstruction::InitAddressBookUpdate { ref update } => {
+            &ProgramInstruction::InitAddressBookUpdate {
+                wallet_account_bump_seed,
+                ref update,
+            } => {
                 let mut update_bytes: Vec<u8> = Vec::new();
                 update.pack(&mut update_bytes);
                 buf.push(TAG_INIT_ADDRESS_BOOK_UPDATE);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(&update_bytes);
             }
-            &ProgramInstruction::FinalizeAddressBookUpdate { ref update } => {
+            &ProgramInstruction::FinalizeAddressBookUpdate {
+                wallet_account_bump_seed,
+                ref update,
+            } => {
                 let mut update_bytes: Vec<u8> = Vec::new();
                 update.pack(&mut update_bytes);
                 buf.push(TAG_FINALIZE_ADDRESS_BOOK_UPDATE);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(&update_bytes);
             }
             &ProgramInstruction::InitBalanceAccountNameUpdate {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref account_name_hash,
             } => {
                 buf.push(TAG_INIT_BALANCE_ACCOUNT_NAME_UPDATE);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(account_guid_hash.to_bytes());
                 buf.extend_from_slice(account_name_hash.to_bytes());
             }
             &ProgramInstruction::FinalizeBalanceAccountNameUpdate {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref account_name_hash,
             } => {
                 buf.push(TAG_FINALIZE_BALANCE_ACCOUNT_NAME_UPDATE);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(account_guid_hash.to_bytes());
                 buf.extend_from_slice(account_name_hash.to_bytes());
             }
             &ProgramInstruction::InitBalanceAccountPolicyUpdate {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref update,
             } => {
                 let mut update_bytes: Vec<u8> = Vec::new();
                 update.pack(&mut update_bytes);
                 buf.push(TAG_INIT_BALANCE_ACCOUNT_POLICY_UPDATE);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(account_guid_hash.to_bytes());
                 buf.extend_from_slice(&update_bytes);
             }
             &ProgramInstruction::FinalizeBalanceAccountPolicyUpdate {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref update,
             } => {
                 let mut update_bytes: Vec<u8> = Vec::new();
                 update.pack(&mut update_bytes);
                 buf.push(TAG_FINALIZE_BALANCE_ACCOUNT_POLICY_UPDATE);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(account_guid_hash.to_bytes());
                 buf.extend_from_slice(&update_bytes);
             }
@@ -548,18 +646,22 @@ impl ProgramInstruction {
                 pack_supply_dapp_transaction_instructions(starting_index, instructions, &mut buf);
             }
             &ProgramInstruction::InitSPLTokenAccountsCreation {
+                wallet_account_bump_seed,
                 ref payer_account_guid_hash,
                 ref account_guid_hashes,
             } => {
                 buf.push(TAG_INIT_BALANCE_ACCOUNT_ENABLE_SPL_TOKEN);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(payer_account_guid_hash.to_bytes());
                 pack_balance_account_guid_hash_vec(account_guid_hashes, &mut buf);
             }
             &ProgramInstruction::FinalizeSPLTokenAccountsCreation {
+                wallet_account_bump_seed,
                 ref payer_account_guid_hash,
                 ref account_guid_hashes,
             } => {
                 buf.push(TAG_FINALIZE_BALANCE_ACCOUNT_ENABLE_SPL_TOKEN);
+                buf.push(wallet_account_bump_seed);
                 buf.extend_from_slice(payer_account_guid_hash.to_bytes());
                 pack_balance_account_guid_hash_vec(account_guid_hashes, &mut buf);
             }
@@ -652,7 +754,8 @@ impl ProgramInstruction {
 
     fn unpack_init_wallet_instruction(bytes: &[u8]) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::InitWallet {
-            initial_config: InitialWalletConfig::unpack(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            initial_config: InitialWalletConfig::unpack(&bytes[1..])?,
         })
     }
 
@@ -660,10 +763,11 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::InitBalanceAccountCreation {
-            account_guid_hash: unpack_account_guid_hash(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            account_guid_hash: unpack_account_guid_hash(&bytes[1..])?,
             creation_params: BalanceAccountCreation::unpack(
                 bytes
-                    .get(HASH_LEN..)
+                    .get(1 + HASH_LEN..)
                     .ok_or(ProgramError::InvalidInstructionData)?,
             )?,
         })
@@ -673,10 +777,11 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::FinalizeBalanceAccountCreation {
-            account_guid_hash: unpack_account_guid_hash(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            account_guid_hash: unpack_account_guid_hash(&bytes[1..])?,
             creation_params: BalanceAccountCreation::unpack(
                 bytes
-                    .get(HASH_LEN..)
+                    .get(1 + HASH_LEN..)
                     .ok_or(ProgramError::InvalidInstructionData)?,
             )?,
         })
@@ -686,10 +791,11 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::InitBalanceAccountPolicyUpdate {
-            account_guid_hash: unpack_account_guid_hash(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            account_guid_hash: unpack_account_guid_hash(&bytes[1..])?,
             update: BalanceAccountPolicyUpdate::unpack(
                 bytes
-                    .get(HASH_LEN..)
+                    .get(1 + HASH_LEN..)
                     .ok_or(ProgramError::InvalidInstructionData)?,
             )?,
         })
@@ -699,10 +805,11 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::FinalizeBalanceAccountPolicyUpdate {
-            account_guid_hash: unpack_account_guid_hash(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            account_guid_hash: unpack_account_guid_hash(&bytes[1..])?,
             update: BalanceAccountPolicyUpdate::unpack(
                 bytes
-                    .get(HASH_LEN..)
+                    .get(1 + HASH_LEN..)
                     .ok_or(ProgramError::InvalidInstructionData)?,
             )?,
         })
@@ -711,15 +818,16 @@ impl ProgramInstruction {
     fn unpack_init_transfer_for_approval_instruction(
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
-        let account_guid_hash = unpack_account_guid_hash(bytes)?;
+        let wallet_account_bump_seed = unpack_u8(bytes)?;
+        let account_guid_hash = unpack_account_guid_hash(&bytes[1..])?;
 
+        let byte_offset = 1 + HASH_LEN + 8;
         let amount = bytes
-            .get(HASH_LEN..HASH_LEN + 8)
+            .get(1 + HASH_LEN..byte_offset)
             .and_then(|slice| slice.try_into().ok())
             .map(u64::from_le_bytes)
             .ok_or(ProgramError::InvalidInstructionData)?;
 
-        let byte_offset = HASH_LEN + 8;
         let destination_name_hash = bytes
             .get(byte_offset..byte_offset + HASH_LEN)
             .and_then(|slice| {
@@ -731,6 +839,7 @@ impl ProgramInstruction {
             .ok_or(ProgramError::InvalidInstructionData)?;
 
         Ok(Self::InitTransfer {
+            wallet_account_bump_seed,
             account_guid_hash,
             amount,
             destination_name_hash,
@@ -757,24 +866,27 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::FinalizeTransfer {
-            account_guid_hash: unpack_account_guid_hash(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            account_guid_hash: unpack_account_guid_hash(&bytes[1..])?,
             amount: bytes
-                .get(HASH_LEN..HASH_LEN + 8)
+                .get(1 + HASH_LEN..1 + HASH_LEN + 8)
                 .and_then(|slice| slice.try_into().ok())
                 .map(u64::from_le_bytes)
                 .ok_or(ProgramError::InvalidInstructionData)?,
-            token_mint: unpack_public_key(bytes, HASH_LEN + 8)?,
+            token_mint: unpack_public_key(bytes, 1 + HASH_LEN + 8)?,
         })
     }
 
     fn unpack_init_wrap_unwrap_instruction(
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
-        if let Some(direction) = bytes.get(40) {
+        let direction_offset = 1 + HASH_LEN + 8;
+        if let Some(direction) = bytes.get(direction_offset) {
             Ok(Self::InitWrapUnwrap {
-                account_guid_hash: unpack_account_guid_hash(bytes)?,
+                wallet_account_bump_seed: unpack_u8(bytes)?,
+                account_guid_hash: unpack_account_guid_hash(&bytes[1..])?,
                 amount: bytes
-                    .get(HASH_LEN..HASH_LEN + 8)
+                    .get(1 + HASH_LEN..direction_offset)
                     .and_then(|slice| slice.try_into().ok())
                     .map(u64::from_le_bytes)
                     .ok_or(ProgramError::InvalidInstructionData)?,
@@ -788,11 +900,13 @@ impl ProgramInstruction {
     fn unpack_finalize_wrap_unwrap_instruction(
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
-        if let Some(direction) = bytes.get(40) {
+        let direction_offset = 1 + HASH_LEN + 8;
+        if let Some(direction) = bytes.get(direction_offset) {
             Ok(Self::FinalizeWrapUnwrap {
-                account_guid_hash: unpack_account_guid_hash(bytes)?,
+                wallet_account_bump_seed: unpack_u8(bytes)?,
+                account_guid_hash: unpack_account_guid_hash(&bytes[1..])?,
                 amount: bytes
-                    .get(HASH_LEN..HASH_LEN + 8)
+                    .get(1 + HASH_LEN..direction_offset)
                     .and_then(|slice| slice.try_into().ok())
                     .map(u64::from_le_bytes)
                     .ok_or(ProgramError::InvalidInstructionData)?,
@@ -806,32 +920,28 @@ impl ProgramInstruction {
     fn unpack_init_update_signer_instruction(
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
-        let (slot_update_type, rest) = bytes
-            .split_first()
-            .ok_or(ProgramError::InvalidInstructionData)?;
-        let (slot_id, rest) = rest
-            .split_first()
-            .ok_or(ProgramError::InvalidInstructionData)?;
+        let wallet_account_bump_seed = unpack_u8(bytes)?;
+        let slot_update_type = unpack_u8(&bytes[1..])?;
+        let slot_id = unpack_u8(&bytes[2..])?;
         Ok(Self::InitUpdateSigner {
-            slot_update_type: SlotUpdateType::from_u8(*slot_update_type),
-            slot_id: SlotId::new(*slot_id as usize),
-            signer: Signer::unpack_from_slice(rest)?,
+            wallet_account_bump_seed,
+            slot_update_type: SlotUpdateType::from_u8(slot_update_type),
+            slot_id: SlotId::new(slot_id as usize),
+            signer: Signer::unpack_from_slice(&bytes[3..])?,
         })
     }
 
     fn unpack_finalize_update_signer_instruction(
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
-        let (slot_update_type, rest) = bytes
-            .split_first()
-            .ok_or(ProgramError::InvalidInstructionData)?;
-        let (slot_id, rest) = rest
-            .split_first()
-            .ok_or(ProgramError::InvalidInstructionData)?;
+        let wallet_account_bump_seed = unpack_u8(bytes)?;
+        let slot_update_type = unpack_u8(&bytes[1..])?;
+        let slot_id = unpack_u8(&bytes[2..])?;
         Ok(Self::FinalizeUpdateSigner {
-            slot_update_type: SlotUpdateType::from_u8(*slot_update_type),
-            slot_id: SlotId::new(*slot_id as usize),
-            signer: Signer::unpack_from_slice(rest)?,
+            wallet_account_bump_seed,
+            slot_update_type: SlotUpdateType::from_u8(slot_update_type),
+            slot_id: SlotId::new(slot_id as usize),
+            signer: Signer::unpack_from_slice(&bytes[3..])?,
         })
     }
 
@@ -839,7 +949,8 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::InitWalletConfigPolicyUpdate {
-            update: WalletConfigPolicyUpdate::unpack(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            update: WalletConfigPolicyUpdate::unpack(&bytes[1..])?,
         })
     }
 
@@ -847,7 +958,8 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::FinalizeWalletConfigPolicyUpdate {
-            update: WalletConfigPolicyUpdate::unpack(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            update: WalletConfigPolicyUpdate::unpack(&bytes[1..])?,
         })
     }
 
@@ -855,6 +967,9 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         let iter = &mut bytes.into_iter();
+        let wallet_account_bump_seed = read_u8(iter)
+            .ok_or(ProgramError::InvalidInstructionData)?
+            .clone();
         let account_guid_hash = unpack_account_guid_hash(
             read_slice(iter, HASH_LEN).ok_or(ProgramError::InvalidInstructionData)?,
         )?;
@@ -863,6 +978,7 @@ impl ProgramInstruction {
         )?;
         let instruction_count = read_u8(iter).ok_or(ProgramError::InvalidInstructionData)?;
         Ok(Self::InitDAppTransaction {
+            wallet_account_bump_seed,
             account_guid_hash,
             dapp,
             instruction_count: *instruction_count,
@@ -873,12 +989,16 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         let iter = &mut bytes.into_iter();
+        let wallet_account_bump_seed = read_u8(iter)
+            .ok_or(ProgramError::InvalidInstructionData)?
+            .clone();
         let account_guid_hash = unpack_account_guid_hash(
             read_slice(iter, HASH_LEN).ok_or(ProgramError::InvalidInstructionData)?,
         )?;
         let params_hash =
             Hash::new(read_slice(iter, HASH_LEN).ok_or(ProgramError::InvalidInstructionData)?);
         Ok(Self::FinalizeDAppTransaction {
+            wallet_account_bump_seed,
             account_guid_hash,
             params_hash,
         })
@@ -888,7 +1008,11 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         let iter = &mut bytes.into_iter();
+        let wallet_account_bump_seed = read_u8(iter)
+            .ok_or(ProgramError::InvalidInstructionData)?
+            .clone();
         Ok(Self::InitAccountSettingsUpdate {
+            wallet_account_bump_seed,
             account_guid_hash: unpack_account_guid_hash(
                 read_slice(iter, HASH_LEN).ok_or(ProgramError::InvalidInstructionData)?,
             )?,
@@ -901,7 +1025,9 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         let iter = &mut bytes.into_iter();
+        let wallet_account_bump_seed = read_u8(iter).ok_or(ProgramError::InvalidInstructionData)?;
         Ok(Self::FinalizeAccountSettingsUpdate {
+            wallet_account_bump_seed: *wallet_account_bump_seed,
             account_guid_hash: unpack_account_guid_hash(
                 read_slice(iter, HASH_LEN).ok_or(ProgramError::InvalidInstructionData)?,
             )?,
@@ -914,7 +1040,8 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::InitDAppBookUpdate {
-            update: DAppBookUpdate::unpack(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            update: DAppBookUpdate::unpack(&bytes[1..])?,
         })
     }
 
@@ -922,7 +1049,8 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::FinalizeDAppBookUpdate {
-            update: DAppBookUpdate::unpack(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            update: DAppBookUpdate::unpack(&bytes[1..])?,
         })
     }
 
@@ -930,7 +1058,8 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::InitAddressBookUpdate {
-            update: AddressBookUpdate::unpack(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            update: AddressBookUpdate::unpack(&bytes[1..])?,
         })
     }
 
@@ -938,7 +1067,8 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::FinalizeAddressBookUpdate {
-            update: AddressBookUpdate::unpack(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            update: AddressBookUpdate::unpack(&bytes[1..])?,
         })
     }
 
@@ -946,10 +1076,11 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::InitBalanceAccountNameUpdate {
-            account_guid_hash: unpack_account_guid_hash(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            account_guid_hash: unpack_account_guid_hash(&bytes[1..])?,
             account_name_hash: unpack_account_name_hash(
                 bytes
-                    .get(HASH_LEN..)
+                    .get(1 + HASH_LEN..)
                     .ok_or(ProgramError::InvalidInstructionData)?,
             )?,
         })
@@ -959,10 +1090,11 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::FinalizeBalanceAccountNameUpdate {
-            account_guid_hash: unpack_account_guid_hash(bytes)?,
+            wallet_account_bump_seed: unpack_u8(bytes)?,
+            account_guid_hash: unpack_account_guid_hash(&bytes[1..])?,
             account_name_hash: unpack_account_name_hash(
                 bytes
-                    .get(HASH_LEN..)
+                    .get(1 + HASH_LEN..)
                     .ok_or(ProgramError::InvalidInstructionData)?,
             )?,
         })
@@ -972,14 +1104,15 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::InitSPLTokenAccountsCreation {
+            wallet_account_bump_seed: unpack_u8(bytes)?,
             payer_account_guid_hash: unpack_account_guid_hash(
                 bytes
-                    .get(0..HASH_LEN)
+                    .get(1..1 + HASH_LEN)
                     .ok_or(ProgramError::InvalidInstructionData)?,
             )?,
             account_guid_hashes: unpack_account_guid_hash_vec(
                 bytes
-                    .get(HASH_LEN..)
+                    .get(1 + HASH_LEN..)
                     .ok_or(ProgramError::InvalidInstructionData)?,
             )?,
         })
@@ -989,14 +1122,15 @@ impl ProgramInstruction {
         bytes: &[u8],
     ) -> Result<ProgramInstruction, ProgramError> {
         Ok(Self::FinalizeSPLTokenAccountsCreation {
+            wallet_account_bump_seed: unpack_u8(bytes)?,
             payer_account_guid_hash: unpack_account_guid_hash(
                 bytes
-                    .get(0..HASH_LEN)
+                    .get(1..1 + HASH_LEN)
                     .ok_or(ProgramError::InvalidInstructionData)?,
             )?,
             account_guid_hashes: unpack_account_guid_hash_vec(
                 bytes
-                    .get(HASH_LEN..)
+                    .get(1 + HASH_LEN..)
                     .ok_or(ProgramError::InvalidInstructionData)?,
             )?,
         })
@@ -1443,6 +1577,13 @@ pub fn unpack_account_guid_hash_vec(
 ) -> Result<Vec<BalanceAccountGuidHash>, ProgramError> {
     let iter = &mut bytes.iter();
     read_account_guid_vec(iter)
+}
+
+fn unpack_u8(bytes: &[u8]) -> Result<u8, ProgramError> {
+    if bytes.len() == 0 {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+    Ok(bytes[0])
 }
 
 fn unpack_account_guid_hash(bytes: &[u8]) -> Result<BalanceAccountGuidHash, ProgramError> {

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -20,96 +20,127 @@ impl Processor {
 
         match instruction {
             ProgramInstruction::InitWallet {
+                wallet_account_bump_seed,
                 initial_config: update,
-            } => init_wallet_handler::handle(program_id, accounts, &update),
-
-            ProgramInstruction::InitWalletConfigPolicyUpdate { update } => {
-                wallet_config_policy_update_handler::init(program_id, accounts, &update)
+            } => {
+                init_wallet_handler::handle(program_id, accounts, wallet_account_bump_seed, &update)
             }
 
-            ProgramInstruction::FinalizeWalletConfigPolicyUpdate { update } => {
-                wallet_config_policy_update_handler::finalize(program_id, accounts, &update)
-            }
+            ProgramInstruction::InitWalletConfigPolicyUpdate {
+                wallet_account_bump_seed,
+                update,
+            } => wallet_config_policy_update_handler::init(
+                program_id,
+                accounts,
+                wallet_account_bump_seed,
+                &update,
+            ),
+
+            ProgramInstruction::FinalizeWalletConfigPolicyUpdate {
+                wallet_account_bump_seed,
+                update,
+            } => wallet_config_policy_update_handler::finalize(
+                program_id,
+                accounts,
+                wallet_account_bump_seed,
+                &update,
+            ),
 
             ProgramInstruction::InitBalanceAccountCreation {
+                wallet_account_bump_seed,
                 account_guid_hash,
                 creation_params,
             } => balance_account_creation_handler::init(
                 program_id,
                 accounts,
+                wallet_account_bump_seed,
                 &account_guid_hash,
                 &creation_params,
             ),
 
             ProgramInstruction::FinalizeBalanceAccountCreation {
+                wallet_account_bump_seed,
                 account_guid_hash,
                 creation_params,
             } => balance_account_creation_handler::finalize(
                 program_id,
                 accounts,
+                wallet_account_bump_seed,
                 &account_guid_hash,
                 &creation_params,
             ),
 
             ProgramInstruction::InitBalanceAccountNameUpdate {
+                wallet_account_bump_seed,
                 account_guid_hash,
                 account_name_hash,
             } => balance_account_name_update_handler::init(
                 program_id,
                 accounts,
+                wallet_account_bump_seed,
                 &account_guid_hash,
                 &account_name_hash,
             ),
 
             ProgramInstruction::FinalizeBalanceAccountNameUpdate {
+                wallet_account_bump_seed,
                 account_guid_hash,
                 account_name_hash,
             } => balance_account_name_update_handler::finalize(
                 program_id,
                 accounts,
+                wallet_account_bump_seed,
                 &account_guid_hash,
                 &account_name_hash,
             ),
 
             ProgramInstruction::InitBalanceAccountPolicyUpdate {
+                wallet_account_bump_seed,
                 account_guid_hash,
                 update,
             } => balance_account_policy_update_handler::init(
                 program_id,
                 accounts,
+                wallet_account_bump_seed,
                 &account_guid_hash,
                 &update,
             ),
 
             ProgramInstruction::FinalizeBalanceAccountPolicyUpdate {
+                wallet_account_bump_seed,
                 account_guid_hash,
                 update,
             } => balance_account_policy_update_handler::finalize(
                 program_id,
                 accounts,
+                wallet_account_bump_seed,
                 &account_guid_hash,
                 &update,
             ),
 
             ProgramInstruction::InitTransfer {
+                wallet_account_bump_seed,
                 account_guid_hash,
                 amount,
                 destination_name_hash,
             } => transfer_handler::init(
                 program_id,
                 &accounts,
+                wallet_account_bump_seed,
                 &account_guid_hash,
                 amount,
                 &destination_name_hash,
             ),
 
             ProgramInstruction::FinalizeTransfer {
+                wallet_account_bump_seed,
                 account_guid_hash,
                 amount,
                 token_mint,
             } => transfer_handler::finalize(
                 program_id,
                 &accounts,
+                wallet_account_bump_seed,
                 &account_guid_hash,
                 amount,
                 token_mint,
@@ -126,60 +157,70 @@ impl Processor {
             ),
 
             ProgramInstruction::InitWrapUnwrap {
+                wallet_account_bump_seed,
                 account_guid_hash,
                 amount,
                 direction,
             } => wrap_unwrap_handler::init(
                 program_id,
                 &accounts,
+                wallet_account_bump_seed,
                 &account_guid_hash,
                 amount,
                 direction,
             ),
 
             ProgramInstruction::FinalizeWrapUnwrap {
+                wallet_account_bump_seed,
                 account_guid_hash,
                 amount,
                 direction,
             } => wrap_unwrap_handler::finalize(
                 program_id,
                 &accounts,
+                wallet_account_bump_seed,
                 &account_guid_hash,
                 amount,
                 direction,
             ),
 
             ProgramInstruction::InitUpdateSigner {
+                wallet_account_bump_seed,
                 slot_update_type,
                 slot_id,
                 signer,
             } => update_signer_handler::init(
                 program_id,
                 &accounts,
+                wallet_account_bump_seed,
                 slot_update_type,
                 slot_id,
                 signer,
             ),
 
             ProgramInstruction::FinalizeUpdateSigner {
+                wallet_account_bump_seed,
                 slot_update_type,
                 slot_id,
                 signer,
             } => update_signer_handler::finalize(
                 program_id,
                 &accounts,
+                wallet_account_bump_seed,
                 slot_update_type,
                 slot_id,
                 signer,
             ),
 
             ProgramInstruction::InitDAppTransaction {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 dapp,
                 instruction_count,
             } => dapp_transaction_handler::init(
                 program_id,
                 accounts,
+                wallet_account_bump_seed,
                 account_guid_hash,
                 dapp,
                 instruction_count,
@@ -196,71 +237,105 @@ impl Processor {
             ),
 
             ProgramInstruction::FinalizeDAppTransaction {
+                wallet_account_bump_seed,
                 ref account_guid_hash,
                 ref params_hash,
             } => dapp_transaction_handler::finalize(
                 program_id,
                 accounts,
+                wallet_account_bump_seed,
                 account_guid_hash,
                 params_hash,
             ),
 
             ProgramInstruction::InitAccountSettingsUpdate {
+                wallet_account_bump_seed,
                 account_guid_hash,
                 whitelist_enabled,
                 dapps_enabled,
             } => balance_account_settings_update_handler::init(
                 program_id,
                 &accounts,
+                wallet_account_bump_seed,
                 &account_guid_hash,
                 whitelist_enabled,
                 dapps_enabled,
             ),
 
             ProgramInstruction::FinalizeAccountSettingsUpdate {
+                wallet_account_bump_seed,
                 account_guid_hash,
                 whitelist_enabled,
                 dapps_enabled,
             } => balance_account_settings_update_handler::finalize(
                 program_id,
                 &accounts,
+                wallet_account_bump_seed,
                 &account_guid_hash,
                 whitelist_enabled,
                 dapps_enabled,
             ),
 
-            ProgramInstruction::InitDAppBookUpdate { update } => {
-                dapp_book_update_handler::init(program_id, &accounts, &update)
-            }
+            ProgramInstruction::InitDAppBookUpdate {
+                wallet_account_bump_seed,
+                update,
+            } => dapp_book_update_handler::init(
+                program_id,
+                &accounts,
+                wallet_account_bump_seed,
+                &update,
+            ),
 
-            ProgramInstruction::FinalizeDAppBookUpdate { update } => {
-                dapp_book_update_handler::finalize(program_id, &accounts, &update)
-            }
+            ProgramInstruction::FinalizeDAppBookUpdate {
+                wallet_account_bump_seed,
+                update,
+            } => dapp_book_update_handler::finalize(
+                program_id,
+                &accounts,
+                wallet_account_bump_seed,
+                &update,
+            ),
 
-            ProgramInstruction::InitAddressBookUpdate { update } => {
-                address_book_update_handler::init(program_id, accounts, &update)
-            }
+            ProgramInstruction::InitAddressBookUpdate {
+                wallet_account_bump_seed,
+                update,
+            } => address_book_update_handler::init(
+                program_id,
+                accounts,
+                wallet_account_bump_seed,
+                &update,
+            ),
 
-            ProgramInstruction::FinalizeAddressBookUpdate { update } => {
-                address_book_update_handler::finalize(program_id, accounts, &update)
-            }
+            ProgramInstruction::FinalizeAddressBookUpdate {
+                wallet_account_bump_seed,
+                update,
+            } => address_book_update_handler::finalize(
+                program_id,
+                accounts,
+                wallet_account_bump_seed,
+                &update,
+            ),
 
             ProgramInstruction::InitSPLTokenAccountsCreation {
+                wallet_account_bump_seed,
                 payer_account_guid_hash,
                 account_guid_hashes,
             } => spl_token_accounts_creation_handler::init(
                 program_id,
                 accounts,
+                wallet_account_bump_seed,
                 &payer_account_guid_hash,
                 &account_guid_hashes,
             ),
 
             ProgramInstruction::FinalizeSPLTokenAccountsCreation {
+                wallet_account_bump_seed,
                 payer_account_guid_hash,
                 account_guid_hashes,
             } => spl_token_accounts_creation_handler::finalize(
                 program_id,
                 accounts,
+                wallet_account_bump_seed,
                 &payer_account_guid_hash,
                 &account_guid_hashes,
             ),

--- a/tests/address_book_update_tests.rs
+++ b/tests/address_book_update_tests.rs
@@ -21,7 +21,7 @@ async fn test_address_book_update() {
 
     let wallet = get_wallet(
         &mut context.pt_context.banks_client,
-        &context.wallet_account.pubkey(),
+        &context.wallet_account,
     )
     .await;
 
@@ -115,11 +115,11 @@ async fn test_address_book_update() {
 
 #[tokio::test]
 async fn test_address_book_failures() {
-    let (mut context, _) = setup_balance_account_tests_and_finalize(Some(32000)).await;
+    let (mut context, _) = setup_balance_account_tests_and_finalize(Some(40000)).await;
 
     let wallet = get_wallet(
         &mut context.pt_context.banks_client,
-        &context.wallet_account.pubkey(),
+        &context.wallet_account,
     )
     .await;
 
@@ -201,7 +201,7 @@ async fn test_address_book_update_initiator_approval() {
 
     let wallet = get_wallet(
         &mut context.pt_context.banks_client,
-        &context.wallet_account.pubkey(),
+        &context.wallet_account,
     )
     .await;
 

--- a/tests/balance_account_creation_tests.rs
+++ b/tests/balance_account_creation_tests.rs
@@ -70,7 +70,7 @@ async fn test_balance_account_creation() {
     // verify that it was created as expected
     let wallet = get_wallet(
         &mut context.pt_context.banks_client,
-        &context.wallet_account.pubkey(),
+        &context.wallet_account,
     )
     .await;
 
@@ -176,7 +176,8 @@ async fn test_balance_account_creation_not_signed_by_rent_collector() {
     let rent_collector = Keypair::new();
     let mut instruction = finalize_balance_account_creation(
         &context.program_id,
-        &context.wallet_account.pubkey(),
+        &context.wallet_account,
+        context.wallet_account_bump_seed,
         &context.multisig_op_account.pubkey(),
         &rent_collector.pubkey(),
         context.balance_account_guid_hash,
@@ -211,7 +212,8 @@ async fn test_balance_account_creation_incorrect_hash() {
     let finalize_transaction_wrong_wallet_guid_hash = Transaction::new_signed_with_payer(
         &[finalize_balance_account_creation(
             &context.program_id,
-            &context.wallet_account.pubkey(),
+            &context.wallet_account,
+            context.wallet_account_bump_seed,
             &context.multisig_op_account.pubkey(),
             &context.pt_context.payer.pubkey(),
             wrong_guid_hash,
@@ -238,7 +240,8 @@ async fn test_balance_account_creation_incorrect_hash() {
     let finalize_transaction_wrong_update = Transaction::new_signed_with_payer(
         &[finalize_balance_account_creation(
             &context.program_id,
-            &context.wallet_account.pubkey(),
+            &context.wallet_account,
+            context.wallet_account_bump_seed,
             &context.multisig_op_account.pubkey(),
             &context.pt_context.payer.pubkey(),
             context.balance_account_guid_hash,
@@ -389,7 +392,7 @@ async fn test_multisig_op_version_mismatch() {
                     &context.multisig_op_account.pubkey(),
                     &approver.pubkey(),
                     ApprovalDisposition::APPROVE,
-                    Hash([0; 32]), // doesn't matter, it will fail for version mismatch first
+                    Hash::new_from_array([0; 32]), // doesn't matter, it will fail for version mismatch first
                 )],
                 Some(&context.pt_context.payer.pubkey()),
                 &[&context.pt_context.payer, approver],
@@ -445,7 +448,7 @@ async fn test_multisig_op_version_mismatch() {
 
     let wallet = get_wallet(
         &mut context.pt_context.banks_client,
-        &context.wallet_account.pubkey(),
+        &context.wallet_account,
     )
     .await;
 

--- a/tests/balance_account_spl_transfer_tests.rs
+++ b/tests/balance_account_spl_transfer_tests.rs
@@ -26,6 +26,7 @@ async fn test_wrap_unwrap() {
     let rent = context.pt_context.banks_client.get_rent().await.unwrap();
     let token_account_rent = rent.minimum_balance(spl_token::state::Account::LEN);
     let multisig_account_rent = rent.minimum_balance(MultisigOp::LEN);
+    let balance_account_rent = rent.minimum_balance(0);
     let wrapped_sol_account = spl_associated_token_account::get_associated_token_address(
         &balance_account,
         &spl_token::native_mint::id(),
@@ -48,7 +49,7 @@ async fn test_wrap_unwrap() {
         TransactionError::InstructionError(1, Custom(1)),
     );
 
-    // move enough into balance account to fund wrapped sol token rent, but NOT what we want to transfer
+    // move enough into balance account to fund wrapped sol token rent and balance account minimum, but NOT what we want to transfer
     context
         .pt_context
         .banks_client
@@ -56,7 +57,7 @@ async fn test_wrap_unwrap() {
             &[system_instruction::transfer(
                 &context.pt_context.payer.pubkey(),
                 &balance_account,
-                token_account_rent,
+                token_account_rent + balance_account_rent,
             )],
             Some(&context.pt_context.payer.pubkey()),
             &[&context.pt_context.payer],
@@ -80,7 +81,7 @@ async fn test_wrap_unwrap() {
         TransactionError::InstructionError(0, Custom(WalletError::InsufficientBalance as u32)),
     );
 
-    // balance account should have 0 SOL now
+    // balance account should have balance account minimum SOL now
     assert_eq!(
         context
             .pt_context
@@ -88,7 +89,7 @@ async fn test_wrap_unwrap() {
             .get_balance(balance_account)
             .await
             .unwrap(),
-        0
+        balance_account_rent
     );
 
     // move enough into balance account to fund the amount
@@ -115,7 +116,7 @@ async fn test_wrap_unwrap() {
             .get_balance(balance_account)
             .await
             .unwrap(),
-        amount
+        balance_account_rent + amount
     );
 
     process_wrap(
@@ -146,7 +147,7 @@ async fn test_wrap_unwrap() {
             .get_balance(balance_account)
             .await
             .unwrap(),
-        0
+        balance_account_rent
     );
 
     let result = process_unwrapping(
@@ -193,7 +194,7 @@ async fn test_wrap_unwrap() {
             .get_balance(balance_account)
             .await
             .unwrap(),
-        unwrap_amount
+        balance_account_rent + unwrap_amount
     );
 }
 
@@ -252,7 +253,7 @@ async fn test_transfer_spl(
         initiator,
         &balance_account,
         Some(&spl_context.mint.pubkey()),
-        None,
+        123,
     )
     .await;
     result.unwrap();
@@ -285,7 +286,8 @@ async fn test_transfer_spl(
             &[finalize_transfer(
                 &context.program_id,
                 &multisig_op_account.pubkey(),
-                &context.wallet_account.pubkey(),
+                &context.wallet_account,
+                context.wallet_account_bump_seed,
                 &balance_account,
                 &context.allowed_destination.address,
                 &context.pt_context.payer.pubkey(),
@@ -323,7 +325,7 @@ async fn test_transfer_spl_insufficient_balance() {
         initiator,
         &balance_account,
         Some(&spl_context.mint.pubkey()),
-        Some(1230),
+        1230,
     )
     .await;
     result.unwrap();
@@ -357,7 +359,8 @@ async fn test_transfer_spl_insufficient_balance() {
                 &[finalize_transfer(
                     &context.program_id,
                     &multisig_op_account.pubkey(),
-                    &context.wallet_account.pubkey(),
+                    &context.wallet_account,
+                    context.wallet_account_bump_seed,
                     &balance_account,
                     &context.allowed_destination.address,
                     &context.pt_context.payer.pubkey(),

--- a/tests/balance_account_update_tests.rs
+++ b/tests/balance_account_update_tests.rs
@@ -39,7 +39,7 @@ async fn test_balance_account_policy_update() {
 
     let wallet = get_wallet(
         &mut context.pt_context.banks_client,
-        &context.wallet_account.pubkey(),
+        &context.wallet_account,
     )
     .await;
     let balance_account = wallet
@@ -59,7 +59,7 @@ async fn test_balance_account_policy_update() {
     // verify that it was updated as expected
     let updated_wallet = get_wallet(
         &mut context.pt_context.banks_client,
-        &context.wallet_account.pubkey(),
+        &context.wallet_account,
     )
     .await;
     let updated_balance_account = updated_wallet
@@ -101,7 +101,7 @@ async fn test_balance_account_policy_update() {
     // verify optional updates
     let mut expected_balance_account = get_wallet(
         &mut context.pt_context.banks_client,
-        &context.wallet_account.pubkey(),
+        &context.wallet_account,
     )
     .await
     .get_balance_account(&context.balance_account_guid_hash)
@@ -125,7 +125,7 @@ async fn test_balance_account_policy_update() {
         expected_balance_account,
         get_wallet(
             &mut context.pt_context.banks_client,
-            &context.wallet_account.pubkey()
+            &context.wallet_account
         )
         .await
         .get_balance_account(&context.balance_account_guid_hash)
@@ -149,7 +149,7 @@ async fn test_balance_account_policy_update() {
         expected_balance_account,
         get_wallet(
             &mut context.pt_context.banks_client,
-            &context.wallet_account.pubkey()
+            &context.wallet_account
         )
         .await
         .get_balance_account(&context.balance_account_guid_hash)
@@ -260,7 +260,8 @@ async fn test_only_one_pending_balance_account_policy_update_allowed_at_time() {
                 ),
                 init_balance_account_policy_update_instruction(
                     &context.program_id,
-                    &context.wallet_account.pubkey(),
+                    &context.wallet_account,
+                    context.wallet_account_bump_seed,
                     &multisig_op_account.pubkey(),
                     &context.initiator_account.pubkey(),
                     context.balance_account_guid_hash,
@@ -288,7 +289,8 @@ async fn test_only_one_pending_balance_account_policy_update_allowed_at_time() {
         &multisig_op_account2,
         init_balance_account_policy_update_instruction(
             &context.program_id,
-            &context.wallet_account.pubkey(),
+            &context.wallet_account,
+            context.wallet_account_bump_seed,
             &multisig_op_account2.pubkey(),
             &context.initiator_account.pubkey(),
             context.balance_account_guid_hash,
@@ -316,7 +318,8 @@ async fn test_only_one_pending_balance_account_policy_update_allowed_at_time() {
         .process_transaction(Transaction::new_signed_with_payer(
             &[finalize_balance_account_policy_update_instruction(
                 &context.program_id,
-                &context.wallet_account.pubkey(),
+                &context.wallet_account,
+                context.wallet_account_bump_seed,
                 &multisig_op_account.pubkey(),
                 &context.pt_context.payer.pubkey(),
                 context.balance_account_guid_hash,
@@ -344,7 +347,8 @@ async fn test_only_one_pending_balance_account_policy_update_allowed_at_time() {
                 ),
                 init_balance_account_policy_update_instruction(
                     &context.program_id,
-                    &context.wallet_account.pubkey(),
+                    &context.wallet_account,
+                    context.wallet_account_bump_seed,
                     &multisig_op_account.pubkey(),
                     &context.initiator_account.pubkey(),
                     context.balance_account_guid_hash,
@@ -369,7 +373,7 @@ async fn test_balance_account_policy_update_is_denied() {
 
     let wallet = get_wallet(
         &mut context.pt_context.banks_client,
-        &context.wallet_account.pubkey(),
+        &context.wallet_account,
     )
     .await;
     let balance_account = wallet
@@ -398,7 +402,8 @@ async fn test_balance_account_policy_update_is_denied() {
             ),
             init_balance_account_policy_update_instruction(
                 &context.program_id,
-                &context.wallet_account.pubkey(),
+                &context.wallet_account,
+                context.wallet_account_bump_seed,
                 &multisig_op_account.pubkey(),
                 &context.initiator_account.pubkey(),
                 context.balance_account_guid_hash,
@@ -448,7 +453,8 @@ async fn test_balance_account_policy_update_is_denied() {
     let finalize_update = Transaction::new_signed_with_payer(
         &[finalize_balance_account_policy_update_instruction(
             &context.program_id,
-            &context.wallet_account.pubkey(),
+            &context.wallet_account,
+            context.wallet_account_bump_seed,
             &multisig_op_account.pubkey(),
             &context.pt_context.payer.pubkey(),
             context.balance_account_guid_hash,
@@ -468,7 +474,7 @@ async fn test_balance_account_policy_update_is_denied() {
     // verify that balance account was not changed
     let wallet_after_update = get_wallet(
         &mut context.pt_context.banks_client,
-        &context.wallet_account.pubkey(),
+        &context.wallet_account,
     )
     .await;
     let balance_account_after_update = wallet
@@ -544,7 +550,8 @@ async fn invalid_balance_account_policy_updates() {
             &multisig_op_account,
             init_balance_account_policy_update_instruction(
                 &context.program_id,
-                &context.wallet_account.pubkey(),
+                &context.wallet_account,
+                context.wallet_account_bump_seed,
                 &multisig_op_account.pubkey(),
                 &context.initiator_account.pubkey(),
                 wrong_balance_account_guid_hash,
@@ -570,7 +577,8 @@ async fn invalid_balance_account_policy_updates() {
             &multisig_op_account,
             init_balance_account_policy_update_instruction(
                 &context.program_id,
-                &context.wallet_account.pubkey(),
+                &context.wallet_account,
+                context.wallet_account_bump_seed,
                 &multisig_op_account.pubkey(),
                 &context.initiator_account.pubkey(),
                 context.balance_account_guid_hash,
@@ -596,7 +604,8 @@ async fn invalid_balance_account_policy_updates() {
             &multisig_op_account,
             init_balance_account_policy_update_instruction(
                 &context.program_id,
-                &context.wallet_account.pubkey(),
+                &context.wallet_account,
+                context.wallet_account_bump_seed,
                 &multisig_op_account.pubkey(),
                 &context.initiator_account.pubkey(),
                 context.balance_account_guid_hash,
@@ -625,7 +634,8 @@ async fn invalid_balance_account_policy_updates() {
             &multisig_op_account,
             init_balance_account_policy_update_instruction(
                 &context.program_id,
-                &context.wallet_account.pubkey(),
+                &context.wallet_account,
+                context.wallet_account_bump_seed,
                 &multisig_op_account.pubkey(),
                 &context.initiator_account.pubkey(),
                 context.balance_account_guid_hash,

--- a/tests/balance_account_update_whitelist_status_tests.rs
+++ b/tests/balance_account_update_whitelist_status_tests.rs
@@ -23,14 +23,8 @@ async fn test_whitelist_status() {
 
     // transfer should go through
     let initiator = &Keypair::from_base58_string(&context.approvers[2].to_base58_string());
-    let (_, result) = setup_transfer_test(
-        context.borrow_mut(),
-        initiator,
-        &balance_account,
-        None,
-        None,
-    )
-    .await;
+    let (_, result) =
+        setup_transfer_test(context.borrow_mut(), initiator, &balance_account, None, 123).await;
     result.unwrap();
 
     // add a whitelisted destination, should fail since whitelisting on
@@ -77,14 +71,8 @@ async fn test_whitelist_status() {
 
     // make sure transfer fails
     let initiator = &Keypair::from_base58_string(&context.approvers[2].to_base58_string());
-    let (_, result) = setup_transfer_test(
-        context.borrow_mut(),
-        initiator,
-        &balance_account,
-        None,
-        None,
-    )
-    .await;
+    let (_, result) =
+        setup_transfer_test(context.borrow_mut(), initiator, &balance_account, None, 123).await;
     assert_eq!(
         result.unwrap_err().unwrap(),
         TransactionError::InstructionError(1, Custom(WalletError::DestinationNotAllowed as u32)),
@@ -95,14 +83,8 @@ async fn test_whitelist_status() {
     verify_whitelist_status(&mut context, BooleanSetting::Off, 0).await;
 
     let initiator = &Keypair::from_base58_string(&context.approvers[2].to_base58_string());
-    let (_, result) = setup_transfer_test(
-        context.borrow_mut(),
-        initiator,
-        &balance_account,
-        None,
-        None,
-    )
-    .await;
+    let (_, result) =
+        setup_transfer_test(context.borrow_mut(), initiator, &balance_account, None, 123).await;
     result.unwrap();
 
     // explicitly turn it on

--- a/tests/common/instructions.rs
+++ b/tests/common/instructions.rs
@@ -27,20 +27,27 @@ use strike_wallet::{
 pub fn init_wallet(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     assistant_account: &Pubkey,
     initial_config: InitialWalletConfig,
+    fee_payer: &Pubkey,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*wallet_account, false),
         AccountMeta::new_readonly(*assistant_account, true),
+        AccountMeta::new_readonly(*fee_payer, true),
+        AccountMeta::new_readonly(system_program::id(), false),
     ];
 
     Instruction {
         program_id: *program_id,
         accounts,
-        data: ProgramInstruction::InitWallet { initial_config }
-            .borrow()
-            .pack(),
+        data: ProgramInstruction::InitWallet {
+            wallet_account_bump_seed,
+            initial_config,
+        }
+        .borrow()
+        .pack(),
     }
 }
 
@@ -93,6 +100,7 @@ pub fn set_approval_disposition(
 pub fn init_balance_account_creation_instruction(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     initiator_account: &Pubkey,
     slot_id: SlotId<BalanceAccount>,
@@ -111,6 +119,7 @@ pub fn init_balance_account_creation_instruction(
         multisig_op_account,
         initiator_account,
         ProgramInstruction::InitBalanceAccountCreation {
+            wallet_account_bump_seed,
             account_guid_hash,
             creation_params: BalanceAccountCreation {
                 slot_id,
@@ -129,12 +138,14 @@ pub fn init_balance_account_creation_instruction(
 pub fn finalize_balance_account_creation(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     rent_collector_account: &Pubkey,
     account_guid_hash: BalanceAccountGuidHash,
     creation_params: BalanceAccountCreation,
 ) -> Instruction {
     let data = ProgramInstruction::FinalizeBalanceAccountCreation {
+        wallet_account_bump_seed,
         account_guid_hash,
         creation_params,
     }
@@ -157,6 +168,7 @@ pub fn finalize_balance_account_creation(
 pub fn init_dapp_book_update(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     initiator_account: &Pubkey,
     update: DAppBookUpdate,
@@ -166,20 +178,27 @@ pub fn init_dapp_book_update(
         wallet_account,
         multisig_op_account,
         initiator_account,
-        ProgramInstruction::InitDAppBookUpdate { update },
+        ProgramInstruction::InitDAppBookUpdate {
+            wallet_account_bump_seed,
+            update,
+        },
     )
 }
 
 pub fn finalize_dapp_book_update(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     rent_collector_account: &Pubkey,
     update: DAppBookUpdate,
 ) -> Instruction {
-    let data = ProgramInstruction::FinalizeDAppBookUpdate { update }
-        .borrow()
-        .pack();
+    let data = ProgramInstruction::FinalizeDAppBookUpdate {
+        wallet_account_bump_seed,
+        update,
+    }
+    .borrow()
+    .pack();
     let accounts = vec![
         AccountMeta::new(*multisig_op_account, false),
         AccountMeta::new(*wallet_account, false),
@@ -197,6 +216,7 @@ pub fn finalize_dapp_book_update(
 pub fn init_balance_account_policy_update_instruction(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     initiator_account: &Pubkey,
     account_guid_hash: BalanceAccountGuidHash,
@@ -211,6 +231,7 @@ pub fn init_balance_account_policy_update_instruction(
             AccountMeta::new_readonly(sysvar::clock::id(), false),
         ],
         data: ProgramInstruction::InitBalanceAccountPolicyUpdate {
+            wallet_account_bump_seed,
             account_guid_hash,
             update: update.clone(),
         }
@@ -222,6 +243,7 @@ pub fn init_balance_account_policy_update_instruction(
 pub fn finalize_balance_account_policy_update_instruction(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     rent_collector_account: &Pubkey,
     account_guid_hash: BalanceAccountGuidHash,
@@ -238,6 +260,7 @@ pub fn finalize_balance_account_policy_update_instruction(
         program_id: *program_id,
         accounts,
         data: ProgramInstruction::FinalizeBalanceAccountPolicyUpdate {
+            wallet_account_bump_seed,
             account_guid_hash,
             update,
         }
@@ -249,6 +272,7 @@ pub fn finalize_balance_account_policy_update_instruction(
 pub fn init_transfer(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     initiator_account: &Pubkey,
     source_account: &Pubkey,
@@ -260,6 +284,7 @@ pub fn init_transfer(
     fee_payer: &Pubkey,
 ) -> Instruction {
     let data = ProgramInstruction::InitTransfer {
+        wallet_account_bump_seed,
         account_guid_hash,
         amount,
         destination_name_hash,
@@ -297,6 +322,7 @@ pub fn finalize_transfer(
     program_id: &Pubkey,
     multisig_op_account: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     source_account: &Pubkey,
     destination_account: &Pubkey,
     rent_collector_account: &Pubkey,
@@ -306,6 +332,7 @@ pub fn finalize_transfer(
     token_authority: Option<&Pubkey>,
 ) -> Instruction {
     let data = ProgramInstruction::FinalizeTransfer {
+        wallet_account_bump_seed,
         account_guid_hash,
         amount,
         token_mint: *token_mint,
@@ -352,6 +379,7 @@ pub fn finalize_transfer(
 pub fn init_wrap_unwrap(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     initiator_account: &Pubkey,
     balance_account: &Pubkey,
@@ -360,6 +388,7 @@ pub fn init_wrap_unwrap(
     direction: WrapDirection,
 ) -> Instruction {
     let data = ProgramInstruction::InitWrapUnwrap {
+        wallet_account_bump_seed,
         account_guid_hash: *account_guid_hash,
         amount,
         direction,
@@ -397,6 +426,7 @@ pub fn finalize_wrap_unwrap(
     program_id: &Pubkey,
     multisig_op_account: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     balance_account: &Pubkey,
     rent_collector_account: &Pubkey,
     account_guid_hash: &BalanceAccountGuidHash,
@@ -404,6 +434,7 @@ pub fn finalize_wrap_unwrap(
     direction: WrapDirection,
 ) -> Instruction {
     let data = ProgramInstruction::FinalizeWrapUnwrap {
+        wallet_account_bump_seed,
         account_guid_hash: *account_guid_hash,
         amount,
         direction,
@@ -437,6 +468,7 @@ pub fn finalize_wrap_unwrap(
 pub fn init_update_signer(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     initiator_account: &Pubkey,
     slot_update_type: SlotUpdateType,
@@ -449,6 +481,7 @@ pub fn init_update_signer(
         multisig_op_account,
         initiator_account,
         ProgramInstruction::InitUpdateSigner {
+            wallet_account_bump_seed,
             slot_update_type,
             slot_id,
             signer,
@@ -459,6 +492,7 @@ pub fn init_update_signer(
 pub fn finalize_update_signer(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     rent_collector_account: &Pubkey,
     slot_update_type: SlotUpdateType,
@@ -466,6 +500,7 @@ pub fn finalize_update_signer(
     signer: Signer,
 ) -> Instruction {
     let data = ProgramInstruction::FinalizeUpdateSigner {
+        wallet_account_bump_seed,
         slot_update_type,
         slot_id,
         signer,
@@ -490,6 +525,7 @@ pub fn finalize_update_signer(
 pub fn init_wallet_config_policy_update_instruction(
     program_id: Pubkey,
     wallet_account: Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: Pubkey,
     initiator_account: Pubkey,
     update: &WalletConfigPolicyUpdate,
@@ -503,6 +539,7 @@ pub fn init_wallet_config_policy_update_instruction(
             AccountMeta::new_readonly(sysvar::clock::id(), false),
         ],
         data: ProgramInstruction::InitWalletConfigPolicyUpdate {
+            wallet_account_bump_seed,
             update: update.clone(),
         }
         .borrow()
@@ -513,6 +550,7 @@ pub fn init_wallet_config_policy_update_instruction(
 pub fn finalize_wallet_config_policy_update_instruction(
     program_id: Pubkey,
     wallet_account: Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: Pubkey,
     rent_collector_account: Pubkey,
     update: &WalletConfigPolicyUpdate,
@@ -526,6 +564,7 @@ pub fn finalize_wallet_config_policy_update_instruction(
             AccountMeta::new_readonly(sysvar::clock::id(), false),
         ],
         data: ProgramInstruction::FinalizeWalletConfigPolicyUpdate {
+            wallet_account_bump_seed,
             update: update.clone(),
         }
         .borrow()
@@ -536,6 +575,7 @@ pub fn finalize_wallet_config_policy_update_instruction(
 pub fn init_dapp_transaction(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     multisig_data_account: &Pubkey,
     initiator_account: &Pubkey,
@@ -544,6 +584,7 @@ pub fn init_dapp_transaction(
     instruction_count: u8,
 ) -> Instruction {
     let data = ProgramInstruction::InitDAppTransaction {
+        wallet_account_bump_seed,
         account_guid_hash: *account_guid_hash,
         dapp,
         instruction_count,
@@ -592,6 +633,7 @@ pub fn supply_dapp_transaction_instructions(
 pub fn finalize_dapp_transaction(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     multisig_data_account: &Pubkey,
     balance_account: &Pubkey,
@@ -601,6 +643,7 @@ pub fn finalize_dapp_transaction(
     instructions: &Vec<Instruction>,
 ) -> Instruction {
     let data = ProgramInstruction::FinalizeDAppTransaction {
+        wallet_account_bump_seed,
         account_guid_hash: *account_guid_hash,
         params_hash: *params_hash,
     }
@@ -640,6 +683,7 @@ pub fn finalize_dapp_transaction(
 pub fn init_account_settings_update(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     initiator_account: &Pubkey,
     account_guid_hash: BalanceAccountGuidHash,
@@ -652,6 +696,7 @@ pub fn init_account_settings_update(
         multisig_op_account,
         initiator_account,
         ProgramInstruction::InitAccountSettingsUpdate {
+            wallet_account_bump_seed,
             account_guid_hash,
             whitelist_enabled: whitelist_status,
             dapps_enabled,
@@ -662,6 +707,7 @@ pub fn init_account_settings_update(
 pub fn finalize_account_settings_update(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     rent_collector_account: &Pubkey,
     account_guid_hash: BalanceAccountGuidHash,
@@ -669,6 +715,7 @@ pub fn finalize_account_settings_update(
     dapps_enabled: Option<BooleanSetting>,
 ) -> Instruction {
     let data = ProgramInstruction::FinalizeAccountSettingsUpdate {
+        wallet_account_bump_seed,
         account_guid_hash,
         whitelist_enabled: whitelist_status,
         dapps_enabled,
@@ -693,6 +740,7 @@ pub fn finalize_account_settings_update(
 pub fn init_balance_account_name_update(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     initiator_account: &Pubkey,
     account_guid_hash: BalanceAccountGuidHash,
@@ -704,6 +752,7 @@ pub fn init_balance_account_name_update(
         multisig_op_account,
         initiator_account,
         ProgramInstruction::InitBalanceAccountNameUpdate {
+            wallet_account_bump_seed,
             account_guid_hash,
             account_name_hash,
         },
@@ -713,12 +762,14 @@ pub fn init_balance_account_name_update(
 pub fn finalize_balance_account_name_update(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     rent_collector_account: &Pubkey,
     account_guid_hash: BalanceAccountGuidHash,
     account_name_hash: BalanceAccountNameHash,
 ) -> Instruction {
     let data = ProgramInstruction::FinalizeBalanceAccountNameUpdate {
+        wallet_account_bump_seed,
         account_guid_hash,
         account_name_hash,
     }
@@ -742,6 +793,7 @@ pub fn finalize_balance_account_name_update(
 pub fn init_address_book_update_instruction(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     initiator_account: &Pubkey,
     add_address_book_entries: Vec<(SlotId<AddressBookEntry>, AddressBookEntry)>,
@@ -754,6 +806,7 @@ pub fn init_address_book_update_instruction(
         multisig_op_account,
         initiator_account,
         ProgramInstruction::InitAddressBookUpdate {
+            wallet_account_bump_seed,
             update: AddressBookUpdate {
                 add_address_book_entries: add_address_book_entries.clone(),
                 remove_address_book_entries: remove_address_book_entries.clone(),
@@ -766,13 +819,17 @@ pub fn init_address_book_update_instruction(
 pub fn finalize_address_book_update(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     rent_collector_account: &Pubkey,
     update: AddressBookUpdate,
 ) -> Instruction {
-    let data = ProgramInstruction::FinalizeAddressBookUpdate { update }
-        .borrow()
-        .pack();
+    let data = ProgramInstruction::FinalizeAddressBookUpdate {
+        wallet_account_bump_seed,
+        update,
+    }
+    .borrow()
+    .pack();
     let accounts = vec![
         AccountMeta::new(*multisig_op_account, false),
         AccountMeta::new(*wallet_account, false),
@@ -790,6 +847,7 @@ pub fn finalize_address_book_update(
 pub fn init_balance_account_enable_spl_token(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     assistant_account: &Pubkey,
     token_mint_account: &Pubkey,
@@ -798,6 +856,7 @@ pub fn init_balance_account_enable_spl_token(
     account_guid_hashes: &Vec<BalanceAccountGuidHash>,
 ) -> Instruction {
     let data = ProgramInstruction::InitSPLTokenAccountsCreation {
+        wallet_account_bump_seed,
         payer_account_guid_hash: payer_account_guid_hash.clone(),
         account_guid_hashes: account_guid_hashes.clone(),
     }
@@ -830,6 +889,7 @@ pub fn init_balance_account_enable_spl_token(
 pub fn finalize_balance_account_enable_spl_token(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
+    wallet_account_bump_seed: u8,
     multisig_op_account: &Pubkey,
     rent_collector_account: &Pubkey,
     token_mint_account: &Pubkey,
@@ -840,6 +900,7 @@ pub fn finalize_balance_account_enable_spl_token(
     account_guid_hashes: &Vec<BalanceAccountGuidHash>,
 ) -> Instruction {
     let data = ProgramInstruction::FinalizeSPLTokenAccountsCreation {
+        wallet_account_bump_seed,
         payer_account_guid_hash: payer_account_guid_hash.clone(),
         account_guid_hashes: account_guid_hashes.clone(),
     }

--- a/tests/wallet_update_signers_tests.rs
+++ b/tests/wallet_update_signers_tests.rs
@@ -165,7 +165,8 @@ async fn test_remove_signer_fails_for_a_transfer_approver() {
         &multisig_op_account,
         instructions::init_update_signer(
             &context.program_id,
-            &context.wallet_account.pubkey(),
+            &context.wallet_account,
+            context.wallet_account_bump_seed,
             &multisig_op_account.pubkey(),
             &context.assistant_account.pubkey(),
             SlotUpdateType::Clear,


### PR DESCRIPTION
## Description
Converted the wallet account to be a PDA, which gets created in the `InitWallet` instruction. `InitWallet` and all other instructions which take the wallet account now also take the bump seed as an argument, and validate that the wallet account is the correct one for the current version of the program.

Added a `rent_return_address` to the wallet account data.

Also updated to the latest version of solana (and also to 2021 edition of Rust). Required changing some unit tests and adding logic to `transfer_sol_checked` to ensure that the source account's balance doesn't fall into the "uncanny valley" between 0 and the empty account minimum rent.

## Motivation and Context
This is a prerequisite for the program upgradeability plan.

## How Has This Been Tested?
All existing tests pass; added a test that sending the wrong bump seed results in a error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

