### PR TITLE
add version and rent_return fields to wallet account

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -62,6 +62,7 @@ pub const TAG_FINALIZE_BALANCE_ACCOUNT_ENABLE_SPL_TOKEN: u8 = 30;
 pub enum ProgramInstruction {
     /// 0. `[writable]` The wallet account
     /// 1. `[signer]` The transaction assistant account
+    /// 2. `[signer]` The rent return account
     InitWallet { initial_config: InitialWalletConfig },
 
     /// 0. `[writable]` The multisig operation account

--- a/tests/common/instructions.rs
+++ b/tests/common/instructions.rs
@@ -28,11 +28,13 @@ pub fn init_wallet(
     program_id: &Pubkey,
     wallet_account: &Pubkey,
     assistant_account: &Pubkey,
+    rent_return_account: &Pubkey,
     initial_config: InitialWalletConfig,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*wallet_account, false),
         AccountMeta::new_readonly(*assistant_account, true),
+        AccountMeta::new_readonly(*rent_return_account, true),
     ];
 
     Instruction {

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -312,6 +312,7 @@ pub async fn init_wallet(
                 &program_id,
                 &wallet_account.pubkey(),
                 &assistant_account.pubkey(),
+                &payer.pubkey(),
                 initial_config,
             ),
         ],

--- a/tests/init_wallet_tests.rs
+++ b/tests/init_wallet_tests.rs
@@ -18,6 +18,7 @@ use strike_wallet::model::address_book::{AddressBook, DAppBook};
 use strike_wallet::model::signer::Signer;
 use strike_wallet::model::wallet::{Approvers, BalanceAccounts, Signers, Wallet};
 use strike_wallet::utils::SlotId;
+use strike_wallet::version::VERSION;
 use {
     solana_program_test::{processor, tokio, ProgramTest},
     solana_sdk::{
@@ -66,6 +67,8 @@ async fn init_wallet() {
         get_wallet(&mut banks_client, &wallet_account.pubkey()).await,
         Wallet {
             is_initialized: true,
+            version: VERSION,
+            rent_return: payer.pubkey().clone(),
             signers: Signers::from_vec(signers),
             assistant: assistant_account.pubkey_as_signer(),
             address_book: AddressBook::new(),


### PR DESCRIPTION
## Description
Add a 4-byte version and rent return pubkey to the wallet account data. They are set in `init_wallet` but otherwise not used.

## Motivation and Context
Needed to support upgradability.

## How Has This Been Tested?
Existing unit tests all pass, and existing `init_wallet_tests` verifies fields are created on `init_wallet`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

