### PR TITLE
add wallet guid to allow multiple wallets per program

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,4 @@
 pub use solana_program::pubkey::PUBKEY_BYTES;
 
 pub const HASH_LEN: usize = 32;
+pub const VERSION_LEN: usize = 4;

--- a/src/error.rs
+++ b/src/error.rs
@@ -138,6 +138,9 @@ pub enum WalletError {
     /// Operation not initialized
     #[error("Invalid Address Book Entries Hash")]
     InvalidAddressBookEntriesHash,
+    /// Wallet Guid Hash did not match
+    #[error("Wallet Guid Hash Mismatch")]
+    WalletGuidHashMismatch,
 }
 
 impl From<WalletError> for ProgramError {

--- a/src/handlers/cleanup_handler.rs
+++ b/src/handlers/cleanup_handler.rs
@@ -11,18 +11,25 @@ use solana_program::pubkey::Pubkey;
 
 pub fn handle(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
-    next_wallet_account_info(accounts_iter, program_id)?;
+    let wallet_account_info = next_wallet_account_info(accounts_iter, program_id)?;
     let cleanup_account_info = next_program_account_info(accounts_iter, program_id)?;
     let rent_return_account_info = next_account_info(accounts_iter)?;
 
-    if Wallet::get_is_initialized(&cleanup_account_info.data.borrow()) {
+    if Wallet::is_initialized_from_slice(&cleanup_account_info.data.borrow()) {
         let cleanup_version = Wallet::version_from_slice(&cleanup_account_info.data.borrow())?;
         if cleanup_version == VERSION {
             return Err(WalletError::AccountVersionMismatch.into());
         }
-        let rent_return = Wallet::get_rent_return(&cleanup_account_info.data.borrow())?;
+        let rent_return = Wallet::rent_return_from_slice(&cleanup_account_info.data.borrow())?;
         if *rent_return_account_info.key != rent_return {
             return Err(WalletError::AccountNotRecognized.into());
+        }
+        let cleanup_wallet_guid_hash =
+            Wallet::wallet_guid_hash_from_slice(&cleanup_account_info.data.borrow())?;
+        let wallet_guid_hash =
+            Wallet::wallet_guid_hash_from_slice(&wallet_account_info.data.borrow())?;
+        if cleanup_wallet_guid_hash != wallet_guid_hash {
+            return Err(WalletError::WalletGuidHashMismatch.into());
         }
     } else {
         return Err(ProgramError::UninitializedAccount);

--- a/src/handlers/init_wallet_handler.rs
+++ b/src/handlers/init_wallet_handler.rs
@@ -1,7 +1,7 @@
 use crate::handlers::utils::next_program_account_info;
 use crate::instruction::InitialWalletConfig;
 use crate::model::signer::Signer;
-use crate::model::wallet::Wallet;
+use crate::model::wallet::{Wallet, WalletGuidHash};
 use crate::version::VERSION;
 use solana_program::account_info::{next_account_info, AccountInfo};
 use solana_program::entrypoint::ProgramResult;
@@ -12,7 +12,8 @@ use solana_program::pubkey::Pubkey;
 pub fn handle(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    update: &InitialWalletConfig,
+    wallet_guid_hash: &WalletGuidHash,
+    initial_config: &InitialWalletConfig,
 ) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
     let wallet_account_info = next_program_account_info(accounts_iter, program_id)?;
@@ -31,10 +32,11 @@ pub fn handle(
     wallet.is_initialized = true;
     wallet.version = VERSION;
     wallet.rent_return = *rent_return_account_info.key;
+    wallet.wallet_guid_hash = *wallet_guid_hash;
     wallet.assistant = Signer {
         key: *assistant_account_info.key,
     };
-    wallet.initialize(update)?;
+    wallet.initialize(initial_config)?;
     Wallet::pack(wallet, &mut wallet_account_info.data.borrow_mut())?;
 
     Ok(())

--- a/src/handlers/migrate_handler.rs
+++ b/src/handlers/migrate_handler.rs
@@ -21,6 +21,7 @@ fn migration_test(source: &AccountInfo, destination: &mut [u8], rent_return: &Pu
         is_initialized: true,
         version: 0,
         rent_return: *rent_return,
+        wallet_guid_hash: source_account.wallet_guid_hash,
         signers: source_account.signers,
         assistant: source_account.assistant,
         address_book: source_account.address_book,
@@ -48,7 +49,7 @@ pub fn handle(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
         return Err(WalletError::AccountVersionMismatch.into());
     }
 
-    if Wallet::get_is_initialized(&destination_account_info.data.borrow()) {
+    if Wallet::is_initialized_from_slice(&destination_account_info.data.borrow()) {
         return Err(ProgramError::AccountAlreadyInitialized);
     }
 

--- a/src/model/balance_account.rs
+++ b/src/model/balance_account.rs
@@ -1,7 +1,7 @@
 use crate::constants::HASH_LEN;
 use crate::model::address_book::{AddressBook, AddressBookEntry};
 use crate::model::multisig_op::BooleanSetting;
-use crate::model::wallet::Approvers;
+use crate::model::wallet::{Approvers, WalletGuidHash};
 use crate::utils::SlotFlags;
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
 use solana_program::program_error::ProgramError;
@@ -159,8 +159,15 @@ impl BalanceAccount {
         return self.allowed_destinations.count_enabled() > 0;
     }
 
-    /// Derive the PDA and "bump seed" of a BalanceAccount, given its GUID hash.
-    pub fn find_address(guid_hash: &BalanceAccountGuidHash, program_id: &Pubkey) -> (Pubkey, u8) {
-        Pubkey::find_program_address(&[&guid_hash.to_bytes()], program_id)
+    /// Derive the PDA and "bump seed" of a BalanceAccount, given its GUID hash and the wallet guid hash.
+    pub fn find_address(
+        wallet_guid_hash: &WalletGuidHash,
+        guid_hash: &BalanceAccountGuidHash,
+        program_id: &Pubkey,
+    ) -> (Pubkey, u8) {
+        Pubkey::find_program_address(
+            &[wallet_guid_hash.to_bytes(), guid_hash.to_bytes()],
+            program_id,
+        )
     }
 }

--- a/src/model/wallet.rs
+++ b/src/model/wallet.rs
@@ -1,4 +1,4 @@
-use crate::constants::HASH_LEN;
+use crate::constants::{HASH_LEN, VERSION_LEN};
 use crate::error::WalletError;
 use crate::instruction::{
     AddressBookUpdate, BalanceAccountCreation, BalanceAccountPolicyUpdate, DAppBookUpdate,
@@ -682,9 +682,9 @@ impl Wallet {
     }
 
     pub fn rent_return_from_slice(src: &[u8]) -> Result<Pubkey, ProgramError> {
-        if src.len() >= 1 + 4 + PUBKEY_BYTES {
+        if src.len() >= 1 + VERSION_LEN + PUBKEY_BYTES {
             if src[0] == 1 {
-                let buf = array_ref!(src, 5, PUBKEY_BYTES);
+                let buf = array_ref!(src, 1 + VERSION_LEN, PUBKEY_BYTES);
                 Ok(Pubkey::new_from_array(*buf))
             } else {
                 Err(ProgramError::UninitializedAccount)
@@ -695,9 +695,9 @@ impl Wallet {
     }
 
     pub fn wallet_guid_hash_from_slice(src: &[u8]) -> Result<WalletGuidHash, ProgramError> {
-        if src.len() >= 1 + 4 + PUBKEY_BYTES + HASH_LEN {
+        if src.len() >= 1 + VERSION_LEN + PUBKEY_BYTES + HASH_LEN {
             if src[0] == 1 {
-                let buf = array_ref!(src, 1 + 4 + PUBKEY_BYTES, HASH_LEN);
+                let buf = array_ref!(src, 1 + VERSION_LEN + PUBKEY_BYTES, HASH_LEN);
                 Ok(WalletGuidHash::new(buf))
             } else {
                 Err(ProgramError::UninitializedAccount)
@@ -762,9 +762,9 @@ impl Wallet {
 
 impl Versioned for Wallet {
     fn version_from_slice(src: &[u8]) -> Result<u32, ProgramError> {
-        if src.len() >= 5 {
+        if src.len() >= 1 + VERSION_LEN {
             if src[0] == 1 {
-                let buf = array_ref!(src, 1, 4);
+                let buf = array_ref!(src, 1, VERSION_LEN);
                 Ok(u32::from_le_bytes(*buf))
             } else {
                 Err(ProgramError::UninitializedAccount)
@@ -777,7 +777,7 @@ impl Versioned for Wallet {
 
 impl Pack for Wallet {
     const LEN: usize = 1 + // is_initialized
-        4 + // version
+        VERSION_LEN + // version
         PUBKEY_BYTES + // rent return
         HASH_LEN + // wallet guid hash
         Signers::LEN +
@@ -807,7 +807,7 @@ impl Pack for Wallet {
         ) = mut_array_refs![
             dst,
             1,
-            4,
+            VERSION_LEN,
             PUBKEY_BYTES,
             HASH_LEN,
             Signers::LEN,
@@ -852,7 +852,7 @@ impl Pack for Wallet {
         ) = array_refs![
             src,
             1,
-            4,
+            VERSION_LEN,
             PUBKEY_BYTES,
             HASH_LEN,
             Signers::LEN,

--- a/src/model/wallet.rs
+++ b/src/model/wallet.rs
@@ -1,3 +1,4 @@
+use crate::constants::HASH_LEN;
 use crate::error::WalletError;
 use crate::instruction::{
     AddressBookUpdate, BalanceAccountCreation, BalanceAccountPolicyUpdate, DAppBookUpdate,
@@ -28,11 +29,29 @@ pub type Signers = Slots<Signer, { Wallet::MAX_SIGNERS }>;
 pub type Approvers = SlotFlags<Signer, { Signers::FLAGS_STORAGE_SIZE }>;
 pub type BalanceAccounts = Slots<BalanceAccount, { Wallet::MAX_BALANCE_ACCOUNTS }>;
 
+#[derive(Debug, Clone, Eq, PartialEq, Copy, Ord, PartialOrd)]
+pub struct WalletGuidHash([u8; HASH_LEN]);
+
+impl WalletGuidHash {
+    pub fn new(bytes: &[u8; HASH_LEN]) -> Self {
+        Self(*bytes)
+    }
+
+    pub fn zero() -> Self {
+        Self::new(&[0; HASH_LEN])
+    }
+
+    pub fn to_bytes(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Wallet {
     pub is_initialized: bool,
     pub version: u32,
     pub rent_return: Pubkey,
+    pub wallet_guid_hash: WalletGuidHash,
     pub signers: Signers,
     pub assistant: Signer,
     pub address_book: AddressBook,
@@ -384,8 +403,13 @@ impl Wallet {
         self.balance_accounts
             .insert(creation_params.slot_id, balance_account);
 
-        let (source_account_pda, _) =
-            Pubkey::find_program_address(&[&account_guid_hash.to_bytes()], program_id);
+        let (source_account_pda, _) = Pubkey::find_program_address(
+            &[
+                self.wallet_guid_hash.to_bytes(),
+                account_guid_hash.to_bytes(),
+            ],
+            program_id,
+        );
 
         self.add_address_book_entries(&vec![(
             creation_params.address_book_slot_id,
@@ -653,15 +677,28 @@ impl Wallet {
         Ok(())
     }
 
-    pub fn get_is_initialized(src: &[u8]) -> bool {
+    pub fn is_initialized_from_slice(src: &[u8]) -> bool {
         return src.len() > 0 && src[0] == 1;
     }
 
-    pub fn get_rent_return(src: &[u8]) -> Result<Pubkey, ProgramError> {
+    pub fn rent_return_from_slice(src: &[u8]) -> Result<Pubkey, ProgramError> {
         if src.len() >= 1 + 4 + PUBKEY_BYTES {
             if src[0] == 1 {
                 let buf = array_ref!(src, 5, PUBKEY_BYTES);
                 Ok(Pubkey::new_from_array(*buf))
+            } else {
+                Err(ProgramError::UninitializedAccount)
+            }
+        } else {
+            Err(ProgramError::InvalidAccountData)
+        }
+    }
+
+    pub fn wallet_guid_hash_from_slice(src: &[u8]) -> Result<WalletGuidHash, ProgramError> {
+        if src.len() >= 1 + 4 + PUBKEY_BYTES + HASH_LEN {
+            if src[0] == 1 {
+                let buf = array_ref!(src, 1 + 4 + PUBKEY_BYTES, HASH_LEN);
+                Ok(WalletGuidHash::new(buf))
             } else {
                 Err(ProgramError::UninitializedAccount)
             }
@@ -742,6 +779,7 @@ impl Pack for Wallet {
     const LEN: usize = 1 + // is_initialized
         4 + // version
         PUBKEY_BYTES + // rent return
+        HASH_LEN + // wallet guid hash
         Signers::LEN +
         Signer::LEN + // assistant
         AddressBook::LEN +
@@ -757,6 +795,7 @@ impl Pack for Wallet {
             is_initialized_dst,
             version_dst,
             rent_return_dst,
+            wallet_guid_hash_dst,
             signers_dst,
             assistant_account_dst,
             address_book_dst,
@@ -770,6 +809,7 @@ impl Pack for Wallet {
             1,
             4,
             PUBKEY_BYTES,
+            HASH_LEN,
             Signers::LEN,
             Signer::LEN,
             AddressBook::LEN,
@@ -783,6 +823,7 @@ impl Pack for Wallet {
         is_initialized_dst[0] = self.is_initialized as u8;
         *version_dst = self.version.to_le_bytes();
         rent_return_dst.copy_from_slice(self.rent_return.as_ref());
+        wallet_guid_hash_dst.copy_from_slice(&self.wallet_guid_hash.0);
         self.signers.pack_into_slice(signers_dst);
         self.assistant.pack_into_slice(assistant_account_dst);
         self.address_book.pack_into_slice(address_book_dst);
@@ -799,6 +840,7 @@ impl Pack for Wallet {
             is_initialized,
             version,
             rent_return,
+            wallet_guid_hash,
             signers_src,
             assistant,
             address_book_src,
@@ -812,6 +854,7 @@ impl Pack for Wallet {
             1,
             4,
             PUBKEY_BYTES,
+            HASH_LEN,
             Signers::LEN,
             Signer::LEN,
             AddressBook::LEN,
@@ -830,6 +873,7 @@ impl Pack for Wallet {
             },
             version: u32::from_le_bytes(*version),
             rent_return: Pubkey::new_from_array(*rent_return),
+            wallet_guid_hash: WalletGuidHash::new(wallet_guid_hash),
             signers: Signers::unpack_from_slice(signers_src)?,
             assistant: Signer::unpack_from_slice(assistant)?,
             address_book: AddressBook::unpack_from_slice(address_book_src)?,

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -21,8 +21,14 @@ impl Processor {
 
         match instruction {
             ProgramInstruction::InitWallet {
-                initial_config: update,
-            } => init_wallet_handler::handle(program_id, accounts, &update),
+                wallet_guid_hash,
+                initial_config,
+            } => init_wallet_handler::handle(
+                program_id,
+                accounts,
+                &wallet_guid_hash,
+                &initial_config,
+            ),
 
             ProgramInstruction::InitWalletConfigPolicyUpdate { update } => {
                 wallet_config_policy_update_handler::init(program_id, accounts, &update)

--- a/tests/common/instructions.rs
+++ b/tests/common/instructions.rs
@@ -10,6 +10,7 @@ use strike_wallet::instruction::{
     pack_supply_dapp_transaction_instructions, BalanceAccountCreation, BalanceAccountPolicyUpdate,
 };
 use strike_wallet::model::balance_account::BalanceAccount;
+use strike_wallet::model::wallet::WalletGuidHash;
 use strike_wallet::{
     instruction::{
         AddressBookUpdate, BalanceAccountWhitelistUpdate, DAppBookUpdate, InitialWalletConfig,
@@ -30,6 +31,7 @@ pub fn init_wallet(
     wallet_account: &Pubkey,
     assistant_account: &Pubkey,
     rent_return_account: &Pubkey,
+    wallet_guid_hash: WalletGuidHash,
     initial_config: InitialWalletConfig,
 ) -> Instruction {
     let accounts = vec![
@@ -41,9 +43,12 @@ pub fn init_wallet(
     Instruction {
         program_id: *program_id,
         accounts,
-        data: ProgramInstruction::InitWallet { initial_config }
-            .borrow()
-            .pack(),
+        data: ProgramInstruction::InitWallet {
+            wallet_guid_hash,
+            initial_config,
+        }
+        .borrow()
+        .pack(),
     }
 }
 

--- a/tests/dapp_book_update_tests.rs
+++ b/tests/dapp_book_update_tests.rs
@@ -13,7 +13,9 @@ use strike_wallet::model::address_book::{DAppBookEntry, DAppBookEntryNameHash};
 use strike_wallet::model::multisig_op::{
     ApprovalDisposition, ApprovalDispositionRecord, MultisigOpParams, OperationDisposition,
 };
+use strike_wallet::model::wallet::WalletGuidHash;
 use strike_wallet::utils::{SlotId, Slots};
+use uuid::Uuid;
 
 #[tokio::test]
 async fn test_dapp_book_update() {
@@ -36,6 +38,7 @@ async fn test_dapp_book_update() {
         &context.program_id,
         &wallet_account,
         &assistant_account,
+        WalletGuidHash::new(&hash_of(Uuid::new_v4().as_bytes())),
         InitialWalletConfig {
             approvals_required_for_config: 1,
             approval_timeout_for_config: Duration::from_secs(3600),
@@ -171,6 +174,7 @@ async fn test_dapp_book_update_initiator_approval() {
         &context.program_id,
         &wallet_account,
         &assistant_account,
+        WalletGuidHash::new(&hash_of(Uuid::new_v4().as_bytes())),
         InitialWalletConfig {
             approvals_required_for_config: 2,
             approval_timeout_for_config: Duration::from_secs(3600),

--- a/tests/init_wallet_tests.rs
+++ b/tests/init_wallet_tests.rs
@@ -16,9 +16,10 @@ use strike_wallet::error::WalletError;
 use strike_wallet::instruction::InitialWalletConfig;
 use strike_wallet::model::address_book::{AddressBook, DAppBook};
 use strike_wallet::model::signer::Signer;
-use strike_wallet::model::wallet::{Approvers, BalanceAccounts, Signers, Wallet};
+use strike_wallet::model::wallet::{Approvers, BalanceAccounts, Signers, Wallet, WalletGuidHash};
 use strike_wallet::utils::SlotId;
 use strike_wallet::version::VERSION;
+use uuid::Uuid;
 use {
     solana_program_test::{processor, tokio, ProgramTest},
     solana_sdk::{
@@ -46,6 +47,8 @@ async fn init_wallet() {
     let wallet_account = Keypair::new();
     let assistant_account = Keypair::new();
 
+    let wallet_guid_hash = WalletGuidHash::new(&hash_of(Uuid::new_v4().as_bytes()));
+
     utils::init_wallet(
         &mut banks_client,
         &payer,
@@ -53,6 +56,7 @@ async fn init_wallet() {
         &program_id,
         &wallet_account,
         &assistant_account,
+        wallet_guid_hash,
         InitialWalletConfig {
             approvals_required_for_config: approvals_required_for_config.clone(),
             approval_timeout_for_config,
@@ -73,6 +77,7 @@ async fn init_wallet() {
             is_initialized: true,
             version: VERSION,
             rent_return: payer.pubkey().clone(),
+            wallet_guid_hash,
             signers: Signers::from_vec(signers),
             assistant: assistant_account.pubkey_as_signer(),
             address_book: AddressBook::new(),
@@ -115,6 +120,7 @@ async fn invalid_wallet_initialization() {
             &program_id,
             &wallet_account,
             &assistant_account,
+            WalletGuidHash::new(&hash_of(Uuid::new_v4().as_bytes())),
             InitialWalletConfig {
                 approvals_required_for_config: 3,
                 approval_timeout_for_config: Duration::from_secs(3600),
@@ -137,6 +143,7 @@ async fn invalid_wallet_initialization() {
             &program_id,
             &wallet_account,
             &assistant_account,
+            WalletGuidHash::new(&hash_of(Uuid::new_v4().as_bytes())),
             InitialWalletConfig {
                 approvals_required_for_config: 1,
                 approval_timeout_for_config: Duration::from_secs(3600),

--- a/tests/wallet_account_version_tests.rs
+++ b/tests/wallet_account_version_tests.rs
@@ -8,13 +8,14 @@ use solana_program_test::{processor, tokio, ProgramTest};
 use solana_sdk::account::{AccountSharedData, ReadableAccount, WritableAccount};
 use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::transaction::TransactionError;
+use uuid::Uuid;
 
 pub use common::instructions::*;
 pub use common::utils;
 pub use common::utils::*;
 use strike_wallet::error::WalletError;
 use strike_wallet::instruction::{InitialWalletConfig, WalletConfigPolicyUpdate};
-use strike_wallet::model::wallet::Wallet;
+use strike_wallet::model::wallet::{Wallet, WalletGuidHash};
 use strike_wallet::processor::Processor;
 use strike_wallet::utils::SlotId;
 
@@ -41,6 +42,7 @@ async fn test_wallet_account_version_mismatch() {
         &program_id,
         &wallet_account,
         &assistant_account,
+        WalletGuidHash::new(&hash_of(Uuid::new_v4().as_bytes())),
         InitialWalletConfig {
             approvals_required_for_config: 1,
             approval_timeout_for_config: Duration::from_secs(3600),

--- a/tests/wallet_config_policy_update_tests.rs
+++ b/tests/wallet_config_policy_update_tests.rs
@@ -16,8 +16,9 @@ use strike_wallet::instruction::{InitialWalletConfig, WalletConfigPolicyUpdate};
 use strike_wallet::model::multisig_op::{
     ApprovalDisposition, ApprovalDispositionRecord, MultisigOpParams, OperationDisposition,
 };
-use strike_wallet::model::wallet::Approvers;
+use strike_wallet::model::wallet::{Approvers, WalletGuidHash};
 use strike_wallet::utils::SlotId;
+use uuid::Uuid;
 
 #[tokio::test]
 async fn wallet_config_policy_update() {
@@ -41,6 +42,7 @@ async fn wallet_config_policy_update() {
         &context.program_id,
         &wallet_account,
         &assistant_account,
+        WalletGuidHash::new(&hash_of(Uuid::new_v4().as_bytes())),
         InitialWalletConfig {
             approvals_required_for_config: 2,
             approval_timeout_for_config: Duration::from_secs(3600),
@@ -190,6 +192,7 @@ async fn invalid_wallet_config_policy_updates() {
         &context.program_id,
         &wallet_account,
         &assistant_account,
+        WalletGuidHash::new(&hash_of(Uuid::new_v4().as_bytes())),
         InitialWalletConfig {
             approvals_required_for_config: 2,
             approval_timeout_for_config: Duration::from_secs(3600),
@@ -276,6 +279,7 @@ async fn wallet_config_policy_update_initiator_approval() {
         &context.program_id,
         &wallet_account,
         &assistant_account,
+        WalletGuidHash::new(&hash_of(Uuid::new_v4().as_bytes())),
         InitialWalletConfig {
             approvals_required_for_config: 2,
             approval_timeout_for_config: Duration::from_secs(3600),


### PR DESCRIPTION
## Description
Added a "wallet_guid_hash" field to the wallet account data. It is populated in InitWallet, and then will be copied over during migrations. The Cleanup instruction will check that the wallet guid hash in the active account matches that in the account to cleanup. Balance account PDAs are derived using the wallet guid hash in addition to the balance account guid hash.

## Motivation and Context
Allows a single program to safely handle an arbitrary number of wallets.

## How Has This Been Tested?
Added error case testing of cleanup instruction if the cleanup account guid hash doesn't match the active account. All other tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

