### PR TITLE
split address book whitelist updates to a separate instruction

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,4 +1,5 @@
 pub mod address_book_update_handler;
+pub mod address_book_whitelist_update_handler;
 pub mod approval_disposition_handler;
 pub mod balance_account_creation_handler;
 pub mod balance_account_name_update_handler;

--- a/src/handlers/address_book_whitelist_update_handler.rs
+++ b/src/handlers/address_book_whitelist_update_handler.rs
@@ -1,0 +1,75 @@
+use crate::handlers::utils::{
+    finalize_multisig_op, get_clock_from_next_account, next_program_account_info,
+    next_wallet_account_info, start_multisig_config_op,
+};
+use crate::instruction::AddressBookWhitelistUpdate;
+use crate::model::balance_account::BalanceAccountGuidHash;
+use crate::model::multisig_op::MultisigOpParams;
+use crate::model::wallet::Wallet;
+use solana_program::account_info::{next_account_info, AccountInfo};
+use solana_program::entrypoint::ProgramResult;
+use solana_program::program_pack::Pack;
+use solana_program::pubkey::Pubkey;
+
+pub fn init(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    account_guid_hash: &BalanceAccountGuidHash,
+    update: &AddressBookWhitelistUpdate,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+    let multisig_op_account_info = next_program_account_info(accounts_iter, program_id)?;
+    let wallet_account_info = next_wallet_account_info(accounts_iter, program_id)?;
+    let initiator_account_info = next_account_info(accounts_iter)?;
+    let clock = get_clock_from_next_account(accounts_iter)?;
+
+    let wallet = Wallet::unpack(&wallet_account_info.data.borrow())?;
+    wallet.validate_config_initiator(initiator_account_info)?;
+    wallet.validate_address_book_whitelist_update(account_guid_hash, update)?;
+
+    start_multisig_config_op(
+        &multisig_op_account_info,
+        &wallet,
+        clock,
+        MultisigOpParams::UpdateAddressBookWhitelist {
+            wallet_address: *wallet_account_info.key,
+            account_guid_hash: *account_guid_hash,
+            update: update.clone(),
+        },
+        *initiator_account_info.key,
+    )?;
+
+    Ok(())
+}
+
+pub fn finalize(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    account_guid_hash: &BalanceAccountGuidHash,
+    update: &AddressBookWhitelistUpdate,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+    let multisig_op_account_info = next_program_account_info(accounts_iter, program_id)?;
+    let wallet_account_info = next_wallet_account_info(accounts_iter, program_id)?;
+    let rent_collector_account_info = next_account_info(accounts_iter)?;
+    let clock = get_clock_from_next_account(accounts_iter)?;
+
+    finalize_multisig_op(
+        &multisig_op_account_info,
+        &rent_collector_account_info,
+        clock,
+        MultisigOpParams::UpdateAddressBookWhitelist {
+            account_guid_hash: *account_guid_hash,
+            wallet_address: *wallet_account_info.key,
+            update: update.clone(),
+        },
+        || -> ProgramResult {
+            let mut wallet = Wallet::unpack(&wallet_account_info.data.borrow_mut())?;
+            wallet.update_address_book_whitelist(account_guid_hash, update)?;
+            Wallet::pack(wallet, &mut wallet_account_info.data.borrow_mut())?;
+            Ok(())
+        },
+    )?;
+
+    Ok(())
+}

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,5 +1,6 @@
 use crate::handlers::{
-    address_book_update_handler, approval_disposition_handler, balance_account_creation_handler,
+    address_book_update_handler, address_book_whitelist_update_handler,
+    approval_disposition_handler, balance_account_creation_handler,
     balance_account_name_update_handler, balance_account_policy_update_handler,
     balance_account_settings_update_handler, cleanup_handler, dapp_book_update_handler,
     dapp_transaction_handler, init_wallet_handler, migrate_handler,
@@ -274,6 +275,26 @@ impl Processor {
 
             ProgramInstruction::Migrate {} => migrate_handler::handle(program_id, accounts),
             ProgramInstruction::Cleanup {} => cleanup_handler::handle(program_id, accounts),
+
+            ProgramInstruction::InitAddressBookWhitelistUpdate {
+                account_guid_hash,
+                update,
+            } => address_book_whitelist_update_handler::init(
+                program_id,
+                accounts,
+                &account_guid_hash,
+                &update,
+            ),
+
+            ProgramInstruction::FinalizeAddressBookWhitelistUpdate {
+                account_guid_hash,
+                update,
+            } => address_book_whitelist_update_handler::finalize(
+                program_id,
+                accounts,
+                &account_guid_hash,
+                &update,
+            ),
         }
     }
 }

--- a/tests/balance_account_transfer_tests.rs
+++ b/tests/balance_account_transfer_tests.rs
@@ -251,10 +251,9 @@ async fn test_transfer_wrong_destination_name_hash() {
 
     account_settings_update(&mut context, Some(BooleanSetting::On), None, None).await;
     let destination_to_add = context.allowed_destination;
-    modify_whitelist(
+    modify_address_book_whitelist(
         &mut context,
         vec![(SlotId::new(0), destination_to_add)],
-        vec![],
         None,
     )
     .await;

--- a/tests/balance_account_update_whitelist_status_tests.rs
+++ b/tests/balance_account_update_whitelist_status_tests.rs
@@ -29,10 +29,9 @@ async fn test_whitelist_status() {
 
     // add a whitelisted destination, should fail since whitelisting on
     let destination_to_add = context.allowed_destination;
-    modify_whitelist(
+    modify_address_book_whitelist(
         &mut context,
         vec![(SlotId::new(0), destination_to_add)],
-        vec![],
         Some(Custom(WalletError::WhitelistDisabled as u32)),
     )
     .await;
@@ -40,10 +39,9 @@ async fn test_whitelist_status() {
     // turn whitelisting on should be able to add destination now
     account_settings_update(&mut context, Some(BooleanSetting::On), None, None).await;
     verify_whitelist_status(&mut context, BooleanSetting::On, 0).await;
-    modify_whitelist(
+    modify_address_book_whitelist(
         &mut context,
         vec![(SlotId::new(0), destination_to_add)],
-        vec![],
         None,
     )
     .await;
@@ -58,14 +56,7 @@ async fn test_whitelist_status() {
     .await;
 
     // remove a whitelisted destination, status should still be On even though whitelist is empty
-    let destination_to_remove = context.allowed_destination;
-    modify_whitelist(
-        &mut context,
-        vec![],
-        vec![(SlotId::new(0), destination_to_remove)],
-        None,
-    )
-    .await;
+    modify_address_book_whitelist(&mut context, vec![], None).await;
 
     verify_whitelist_status(&mut context, BooleanSetting::On, 0).await;
 
@@ -105,10 +96,9 @@ async fn test_modify_whitelist_when_account_guid_invalid() {
 
     // add a whitelisted destination, should fail due to invalid account guid.
     let destination_to_add = context.allowed_destination;
-    modify_whitelist(
+    modify_address_book_whitelist(
         &mut context,
         vec![(SlotId::new(0), destination_to_add)],
-        vec![],
         Some(Custom(WalletError::BalanceAccountNotFound as u32)),
     )
     .await;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
added separate instruction for whitelist updates 
## Description
<!--- Describe your changes in detail -->
- added separate instruction for whitelist updates 
- when setting whitelist in new instruction the new entire whitelist is specified (not adds/removes)
- existing address book updates still allows whitelist to be modified but that will be deprecated eventually 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- simplifies multisig approvals 
- Entry Web UI only updates whitelist separately so more aligned with how the program is being used

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

