### PR TITLE
change dapp transactions to use number of approvers from transfer policy

### DIFF
--- a/src/handlers/dapp_transaction_handler.rs
+++ b/src/handlers/dapp_transaction_handler.rs
@@ -59,7 +59,7 @@ pub fn init(
     multisig_op.init(
         wallet.get_transfer_approvers_keys(&balance_account),
         (*initiator_account_info.key, ApprovalDisposition::NONE),
-        1,
+        balance_account.approvals_required_for_transfer,
         clock.unix_timestamp,
         calculate_expires(
             clock.unix_timestamp,

--- a/tests/dapp_transaction_tests.rs
+++ b/tests/dapp_transaction_tests.rs
@@ -327,25 +327,26 @@ async fn test_dapp_transaction() {
         dapp_test.multisig_op_account.pubkey(),
     )
     .await;
-    let approver = &context.approvers[0];
-    let approve_transaction = Transaction::new_signed_with_payer(
-        &[set_approval_disposition(
-            &context.program_id,
-            &dapp_test.multisig_op_account.pubkey(),
-            &approver.pubkey(),
-            ApprovalDisposition::APPROVE,
-            params_hash,
-        )],
-        Some(&context.pt_context.payer.pubkey()),
-        &[&context.pt_context.payer, approver],
-        context.pt_context.last_blockhash,
-    );
-    context
-        .pt_context
-        .banks_client
-        .process_transaction(approve_transaction)
-        .await
-        .unwrap();
+    for approver in vec![&context.approvers[0], &context.approvers[1]] {
+        let approve_transaction = Transaction::new_signed_with_payer(
+            &[set_approval_disposition(
+                &context.program_id,
+                &dapp_test.multisig_op_account.pubkey(),
+                &approver.pubkey(),
+                ApprovalDisposition::APPROVE,
+                params_hash,
+            )],
+            Some(&context.pt_context.payer.pubkey()),
+            &[&context.pt_context.payer, approver],
+            context.pt_context.last_blockhash,
+        );
+        context
+            .pt_context
+            .banks_client
+            .process_transaction(approve_transaction)
+            .await
+            .unwrap();
+    }
 
     context
         .pt_context
@@ -399,25 +400,26 @@ async fn test_dapp_transaction_denied() {
         dapp_test.multisig_op_account.pubkey(),
     )
     .await;
-    let approver = &context.approvers[0];
-    let approve_transaction = Transaction::new_signed_with_payer(
-        &[set_approval_disposition(
-            &context.program_id,
-            &dapp_test.multisig_op_account.pubkey(),
-            &approver.pubkey(),
-            ApprovalDisposition::DENY,
-            params_hash,
-        )],
-        Some(&context.pt_context.payer.pubkey()),
-        &[&context.pt_context.payer, approver],
-        context.pt_context.last_blockhash,
-    );
-    context
-        .pt_context
-        .banks_client
-        .process_transaction(approve_transaction)
-        .await
-        .unwrap();
+    for approver in vec![&context.approvers[0], &context.approvers[1]] {
+        let approve_transaction = Transaction::new_signed_with_payer(
+            &[set_approval_disposition(
+                &context.program_id,
+                &dapp_test.multisig_op_account.pubkey(),
+                &approver.pubkey(),
+                ApprovalDisposition::DENY,
+                params_hash,
+            )],
+            Some(&context.pt_context.payer.pubkey()),
+            &[&context.pt_context.payer, approver],
+            context.pt_context.last_blockhash,
+        );
+        context
+            .pt_context
+            .banks_client
+            .process_transaction(approve_transaction)
+            .await
+            .unwrap();
+    }
 
     context
         .pt_context


### PR DESCRIPTION
## Description
Instead of hard-coded to 1 required approver, change dapp transactions to use transfer policy 

## Motivation and Context
To simplify and rationalize the security policy.

## How Has This Been Tested?
Existing tests changed to account

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

