### PR TITLE
exclude security_txt from no-entrypoint builds

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -1,5 +1,6 @@
 use solana_security_txt::security_txt;
 
+#[cfg(not(feature = "no-entrypoint"))]
 security_txt! {
     name: "Strike Wallet",
     project_url: "https://strikeprotocols.com",


### PR DESCRIPTION
## Description
This PR includes the recommended changes from the updated usage guide of `solana-security-txt`.

## Motivation and Context
The usage of `solana-security-txt` previously recommended in the official usage guide has an issue:

When multiple projects within a build, including dependencies, define a security-txt, the build fails.

To avoid this issue, library authors - including projects that *might* be used as a library by others in the future - should exclude the `security_txt` macro during `no-entrypoint` builds.

Feel free to read up on the details in [the issue on the security-txt repository](https://github.com/neodyme-labs/solana-security-txt/issues/11).

The [official usage guide](https://github.com/neodyme-labs/solana-security-txt#usage) has also been updated. This PR includes the recommended changes.

## How Has This Been Tested?
This has been tested on the example contract in the `solana-security-txt`.

This has *not* been tested with your project.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Bug fix breaking (fix that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature breaking (change which adds functionality and causes existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

This PR is more of a notice that the usage guide has changed. Feel free to close it if you don't think the change is necessary for your project or you think the change violates some of your contribution guidelines.

